### PR TITLE
fix(ci): use PAT for semantic-release to bypass branch ruleset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: false
+          token: ${{ secrets.PAT_WORKFLOWS }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -36,5 +36,5 @@ jobs:
 
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT_WORKFLOWS }}
         run: npx semantic-release


### PR DESCRIPTION
## Summary
- Switches `release.yml` from `GITHUB_TOKEN` to `PAT_WORKFLOWS` for both checkout and semantic-release
- `GITHUB_TOKEN` cannot bypass branch rulesets, so semantic-release would fail when pushing CHANGELOG.md and package.json back to `main`
- `PAT_WORKFLOWS` authenticates as the repo owner who is on the bypass list

## Related
- Part of #204 (branch ruleset updates)

## Test plan
- [ ] Verify semantic-release can push to `main` after a merge (will be tested on first real release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)