### PR TITLE
feat: setup identity by UUID with slug redirects

### DIFF
--- a/cli/src/commands/clone.test.ts
+++ b/cli/src/commands/clone.test.ts
@@ -471,6 +471,35 @@ describe('clone — tracking file', () => {
 
 		expect(ctx.fs.writeJson).not.toHaveBeenCalled();
 	});
+
+	it('writes sourceId (UUID) from setup metadata into coati.json', async () => {
+		const program = makeProgram();
+		await program.parseAsync(['clone', 'alice/my-setup'], { from: 'user' });
+
+		expect(ctx.fs.writeJson).toHaveBeenCalledWith(
+			expect.stringContaining('coati.json'),
+			expect.objectContaining({
+				sourceId: 'setup-1'
+			})
+		);
+	});
+
+	it('refreshes source from server ownerUsername/slug (handles renamed setups)', async () => {
+		vi.mocked(ctx.api.get).mockImplementation((url: string) => {
+			if (url.endsWith('/files')) return Promise.resolve(SETUP_FILES);
+			return Promise.resolve({ ...SETUP_META, ownerUsername: 'alice', slug: 'renamed-setup' });
+		});
+
+		const program = makeProgram();
+		await program.parseAsync(['clone', 'alice/my-setup'], { from: 'user' });
+
+		expect(ctx.fs.writeJson).toHaveBeenCalledWith(
+			expect.stringContaining('coati.json'),
+			expect.objectContaining({
+				source: 'alice/renamed-setup'
+			})
+		);
+	});
 });
 
 // ── error messages ────────────────────────────────────────────────────────────

--- a/cli/src/commands/clone.ts
+++ b/cli/src/commands/clone.ts
@@ -263,7 +263,8 @@ export function registerClone(program: Command, ctx: CommandContext): void {
 
 				// Write clone-tracking coati.json to the destination directory
 				ctx.fs.writeJson(path.join(projectDir, MANIFEST_FILENAME), {
-					source: `${owner}/${slug}`,
+					source: `${setup.ownerUsername}/${setup.slug}`,
+					sourceId: setup.id,
 					clonedAt: new Date().toISOString(),
 					revision: setup.version ?? setup.id
 				});

--- a/cli/src/commands/publish.test.ts
+++ b/cli/src/commands/publish.test.ts
@@ -55,18 +55,22 @@ const MOCK_CONFIG = {
 	apiBase: 'https://coati.sh/api/v1'
 };
 
-const MOCK_MANIFEST = {
+const MOCK_MANIFEST: Manifest = {
 	name: 'my-setup',
 	version: '1.0.0',
 	description: 'A test setup',
+	placement: 'global',
 	files: [
 		{
-			source: '.claude/commands/foo.md',
-			target: '.claude/commands/foo.md',
-			placement: 'global',
+			path: '.claude/commands/foo.md',
 			componentType: 'command'
 		}
 	]
+};
+
+const MOCK_MANIFEST_WITH_ID: Manifest = {
+	...MOCK_MANIFEST,
+	id: 'setup-uuid-123'
 };
 
 const MOCK_SETUP_RESPONSE = {
@@ -102,8 +106,6 @@ beforeEach(() => {
 	});
 	mockReadManifest.mockReturnValue(MOCK_MANIFEST);
 	mockReadFileSync.mockReturnValue('file content here');
-	// Default: setup doesn't exist (404)
-	vi.mocked(ctx.api.get).mockRejectedValue(new ApiError('Not Found', 'NOT_FOUND', 404));
 	vi.mocked(ctx.api.post).mockResolvedValue(MOCK_SETUP_RESPONSE);
 	vi.mocked(ctx.api.patch).mockResolvedValue(MOCK_SETUP_RESPONSE);
 	mockRunInitFlow.mockResolvedValue(true);
@@ -184,10 +186,10 @@ describe('missing setup.json', () => {
 	});
 });
 
-// ── create new setup (POST) ───────────────────────────────────────────────────
+// ── Branch 1: no id in manifest → POST → write id back ───────────────────────
 
-describe('create new setup', () => {
-	it('calls POST /setups when setup does not exist', async () => {
+describe('create new setup (no id in manifest)', () => {
+	it('calls POST /setups when manifest has no id', async () => {
 		const program = makeProgram();
 		await program.parseAsync(['node', 'coati', 'publish']);
 
@@ -199,21 +201,61 @@ describe('create new setup', () => {
 				description: 'A test setup',
 				files: expect.arrayContaining([
 					expect.objectContaining({
-						source: '.claude/commands/foo.md',
-						target: '.claude/commands/foo.md',
-						placement: 'global',
+						path: '.claude/commands/foo.md',
 						componentType: 'command',
 						content: 'file content here'
 					})
 				])
 			})
 		);
-		const postCall = vi.mocked(ctx.api.post).mock.calls[0][1] as Record<string, unknown>;
-		expect(postCall).not.toHaveProperty('version');
 		expect(ctx.api.patch).not.toHaveBeenCalled();
 	});
 
-	it('displays success message with setup URL', async () => {
+	it('does not include version in POST payload', async () => {
+		const program = makeProgram();
+		await program.parseAsync(['node', 'coati', 'publish']);
+
+		const postCall = vi.mocked(ctx.api.post).mock.calls[0][1] as Record<string, unknown>;
+		expect(postCall).not.toHaveProperty('version');
+	});
+
+	it('writes the returned id back into coati.json', async () => {
+		const program = makeProgram();
+		await program.parseAsync(['node', 'coati', 'publish']);
+
+		expect(mockWriteManifest).toHaveBeenCalledWith(
+			expect.any(String),
+			expect.objectContaining({ id: 'setup-123' })
+		);
+	});
+
+	it('places id after $schema and before name in written manifest', async () => {
+		mockReadManifest.mockReturnValue({ ...MOCK_MANIFEST, $schema: 'https://example.com/schema' });
+		const program = makeProgram();
+		await program.parseAsync(['node', 'coati', 'publish']);
+
+		const [, writtenManifest] = mockWriteManifest.mock.calls[0] as [
+			string,
+			Record<string, unknown>
+		];
+		const keys = Object.keys(writtenManifest);
+		expect(keys.indexOf('$schema')).toBeLessThan(keys.indexOf('id'));
+		expect(keys.indexOf('id')).toBeLessThan(keys.indexOf('name'));
+	});
+
+	it('places id before name when no $schema field', async () => {
+		const program = makeProgram();
+		await program.parseAsync(['node', 'coati', 'publish']);
+
+		const [, writtenManifest] = mockWriteManifest.mock.calls[0] as [
+			string,
+			Record<string, unknown>
+		];
+		const keys = Object.keys(writtenManifest);
+		expect(keys.indexOf('id')).toBeLessThan(keys.indexOf('name'));
+	});
+
+	it('displays published success message with setup URL', async () => {
 		const program = makeProgram();
 		await program.parseAsync(['node', 'coati', 'publish']);
 
@@ -222,19 +264,19 @@ describe('create new setup', () => {
 	});
 });
 
-// ── update existing setup (PATCH) ─────────────────────────────────────────────
+// ── Branch 2: has id, owns it → PATCH /setups/{id} ────────────────────────────
 
-describe('update existing setup', () => {
+describe('update existing setup (has id in manifest)', () => {
 	beforeEach(() => {
-		vi.mocked(ctx.api.get).mockResolvedValue(MOCK_SETUP_RESPONSE);
+		mockReadManifest.mockReturnValue(MOCK_MANIFEST_WITH_ID);
 	});
 
-	it('calls PATCH /setups/{owner}/{slug} when setup exists', async () => {
+	it('calls PATCH /setups/{id} when manifest has id', async () => {
 		const program = makeProgram();
 		await program.parseAsync(['node', 'coati', 'publish']);
 
 		expect(ctx.api.patch).toHaveBeenCalledWith(
-			'/setups/alice/my-setup',
+			'/setups/setup-uuid-123',
 			expect.objectContaining({
 				name: 'my-setup',
 				files: expect.arrayContaining([expect.objectContaining({ content: 'file content here' })])
@@ -243,12 +285,70 @@ describe('update existing setup', () => {
 		expect(ctx.api.post).not.toHaveBeenCalled();
 	});
 
-	it('displays updated message with setup URL', async () => {
+	it('does not include id or version in PATCH payload', async () => {
+		const program = makeProgram();
+		await program.parseAsync(['node', 'coati', 'publish']);
+
+		const patchCall = vi.mocked(ctx.api.patch).mock.calls[0][1] as Record<string, unknown>;
+		expect(patchCall).not.toHaveProperty('id');
+		expect(patchCall).not.toHaveProperty('version');
+	});
+
+	it('displays updated success message with setup URL', async () => {
 		const program = makeProgram();
 		await program.parseAsync(['node', 'coati', 'publish']);
 
 		expect(ctx.io.success).toHaveBeenCalledWith(expect.stringContaining('updated'));
 		expect(ctx.io.print).toHaveBeenCalledWith(expect.stringContaining('alice/my-setup'));
+	});
+
+	it('does not write id back to coati.json on update', async () => {
+		const program = makeProgram();
+		await program.parseAsync(['node', 'coati', 'publish']);
+
+		expect(mockWriteManifest).not.toHaveBeenCalled();
+	});
+});
+
+// ── Branch 3: has id, server returns 404 ─────────────────────────────────────
+
+describe('update with id — 404 response', () => {
+	beforeEach(() => {
+		mockReadManifest.mockReturnValue(MOCK_MANIFEST_WITH_ID);
+		vi.mocked(ctx.api.patch).mockRejectedValue(new ApiError('Not Found', 'NOT_FOUND', 404));
+	});
+
+	it('shows error telling user to remove id from coati.json', async () => {
+		const program = makeProgram();
+		const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+			throw new Error('process.exit');
+		});
+
+		await expect(program.parseAsync(['node', 'coati', 'publish'])).rejects.toThrow('process.exit');
+		expect(ctx.io.error).toHaveBeenCalledWith(
+			'Setup with this ID no longer exists. Remove `id` from coati.json to publish as new.'
+		);
+		expect(exitSpy).toHaveBeenCalledWith(1);
+	});
+});
+
+// ── Branch 4: has id, server returns 403 ─────────────────────────────────────
+
+describe('update with id — 403 response', () => {
+	beforeEach(() => {
+		mockReadManifest.mockReturnValue(MOCK_MANIFEST_WITH_ID);
+		vi.mocked(ctx.api.patch).mockRejectedValue(new ApiError('Forbidden', 'FORBIDDEN', 403));
+	});
+
+	it('shows ownership error message', async () => {
+		const program = makeProgram();
+		const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+			throw new Error('process.exit');
+		});
+
+		await expect(program.parseAsync(['node', 'coati', 'publish'])).rejects.toThrow('process.exit');
+		expect(ctx.io.error).toHaveBeenCalledWith("You don't own the setup with this ID.");
+		expect(exitSpy).toHaveBeenCalledWith(1);
 	});
 });
 
@@ -277,7 +377,7 @@ describe('--json mode', () => {
 
 	it('outputs structured JSON on successful update', async () => {
 		vi.mocked(ctx.io.isJson).mockReturnValue(true);
-		vi.mocked(ctx.api.get).mockResolvedValue(MOCK_SETUP_RESPONSE);
+		mockReadManifest.mockReturnValue(MOCK_MANIFEST_WITH_ID);
 		const program = makeProgram();
 		await program.parseAsync(['node', 'coati', 'publish', '--json']);
 
@@ -300,6 +400,7 @@ describe('validateAgentRefs', () => {
 			name: 'my-setup',
 			version: '1.0.0',
 			description: 'test',
+			placement: 'global',
 			files: [],
 			...overrides
 		};
@@ -307,7 +408,7 @@ describe('validateAgentRefs', () => {
 
 	it('returns manifest unchanged when no files have agent fields', async () => {
 		const manifest = makeManifest({
-			files: [{ source: 'README.md', target: 'README.md', placement: 'project' }]
+			files: [{ path: 'README.md' }]
 		});
 		const result = await validateAgentRefs(ctx, manifest, CWD);
 		expect(result).toEqual(manifest);
@@ -317,14 +418,7 @@ describe('validateAgentRefs', () => {
 	it('returns manifest unchanged when all file agents are in agents array', async () => {
 		const manifest = makeManifest({
 			agents: ['claude-code'],
-			files: [
-				{
-					source: 'CLAUDE.md',
-					target: 'CLAUDE.md',
-					placement: 'project',
-					agent: 'claude-code'
-				}
-			]
+			files: [{ path: 'CLAUDE.md', agent: 'claude-code' }]
 		});
 		const result = await validateAgentRefs(ctx, manifest, CWD);
 		expect(result).toEqual(manifest);
@@ -334,7 +428,7 @@ describe('validateAgentRefs', () => {
 
 	it('returns null and errors for unknown agent slug', async () => {
 		const manifest = makeManifest({
-			files: [{ source: '.foo', target: '.foo', placement: 'project', agent: 'totally-unknown' }]
+			files: [{ path: '.foo', agent: 'totally-unknown' }]
 		});
 		const result = await validateAgentRefs(ctx, manifest, CWD);
 		expect(result).toBeNull();
@@ -344,8 +438,8 @@ describe('validateAgentRefs', () => {
 	it('returns null for multiple unknown agent slugs', async () => {
 		const manifest = makeManifest({
 			files: [
-				{ source: '.foo', target: '.foo', placement: 'project', agent: 'bad-agent-1' },
-				{ source: '.bar', target: '.bar', placement: 'project', agent: 'bad-agent-2' }
+				{ path: '.foo', agent: 'bad-agent-1' },
+				{ path: '.bar', agent: 'bad-agent-2' }
 			]
 		});
 		const result = await validateAgentRefs(ctx, manifest, CWD);
@@ -357,9 +451,7 @@ describe('validateAgentRefs', () => {
 		vi.mocked(ctx.io.confirm).mockResolvedValue(false);
 		const manifest = makeManifest({
 			agents: [],
-			files: [
-				{ source: '.cursorrules', target: '.cursorrules', placement: 'project', agent: 'cursor' }
-			]
+			files: [{ path: '.cursorrules', agent: 'cursor' }]
 		});
 		const result = await validateAgentRefs(ctx, manifest, CWD);
 		expect(result).not.toBeNull();
@@ -372,9 +464,7 @@ describe('validateAgentRefs', () => {
 		vi.mocked(ctx.io.confirm).mockResolvedValue(true);
 		const manifest = makeManifest({
 			agents: [],
-			files: [
-				{ source: '.cursorrules', target: '.cursorrules', placement: 'project', agent: 'cursor' }
-			]
+			files: [{ path: '.cursorrules', agent: 'cursor' }]
 		});
 		const result = await validateAgentRefs(ctx, manifest, CWD);
 		expect(result).not.toBeNull();
@@ -389,9 +479,7 @@ describe('validateAgentRefs', () => {
 		vi.mocked(ctx.io.confirm).mockResolvedValue(false);
 		const manifest = makeManifest({
 			agents: [],
-			files: [
-				{ source: '.cursorrules', target: '.cursorrules', placement: 'project', agent: 'cursor' }
-			]
+			files: [{ path: '.cursorrules', agent: 'cursor' }]
 		});
 		const result = await validateAgentRefs(ctx, manifest, CWD);
 		expect(result).not.toBeNull();
@@ -406,8 +494,8 @@ describe('validateAgentRefs', () => {
 		const manifest = makeManifest({
 			agents: [],
 			files: [
-				{ source: 'CLAUDE.md', target: 'CLAUDE.md', placement: 'project', agent: 'claude-code' },
-				{ source: '.cursorrules', target: '.cursorrules', placement: 'project', agent: 'cursor' }
+				{ path: 'CLAUDE.md', agent: 'claude-code' },
+				{ path: '.cursorrules', agent: 'cursor' }
 			]
 		});
 		const result = await validateAgentRefs(ctx, manifest, CWD);
@@ -420,9 +508,7 @@ describe('validateAgentRefs', () => {
 		vi.mocked(ctx.io.isJson).mockReturnValue(true);
 		const manifest = makeManifest({
 			agents: [],
-			files: [
-				{ source: '.cursorrules', target: '.cursorrules', placement: 'project', agent: 'cursor' }
-			]
+			files: [{ path: '.cursorrules', agent: 'cursor' }]
 		});
 		const result = await validateAgentRefs(ctx, manifest, CWD);
 		expect(result).not.toBeNull();
@@ -438,9 +524,7 @@ describe('agent validation during publish', () => {
 			...MOCK_MANIFEST,
 			files: [
 				{
-					source: '.claude/commands/foo.md',
-					target: '.claude/commands/foo.md',
-					placement: 'global',
+					path: '.claude/commands/foo.md',
 					componentType: 'command',
 					agent: 'nonexistent-agent'
 				}
@@ -462,14 +546,7 @@ describe('agent validation during publish', () => {
 		mockReadManifest.mockReturnValue({
 			...MOCK_MANIFEST,
 			agents: [],
-			files: [
-				{
-					source: '.cursorrules',
-					target: '.cursorrules',
-					placement: 'project',
-					agent: 'cursor'
-				}
-			]
+			files: [{ path: '.cursorrules', agent: 'cursor' }]
 		});
 		const program = makeProgram();
 		await program.parseAsync(['node', 'coati', 'publish']);
@@ -483,14 +560,7 @@ describe('agent validation during publish', () => {
 		mockReadManifest.mockReturnValue({
 			...MOCK_MANIFEST,
 			agents: [],
-			files: [
-				{
-					source: '.cursorrules',
-					target: '.cursorrules',
-					placement: 'project',
-					agent: 'cursor'
-				}
-			]
+			files: [{ path: '.cursorrules', agent: 'cursor' }]
 		});
 		const program = makeProgram();
 		await program.parseAsync(['node', 'coati', 'publish']);

--- a/cli/src/commands/publish.ts
+++ b/cli/src/commands/publish.ts
@@ -81,6 +81,18 @@ export async function validateAgentRefs(
 	return manifest;
 }
 
+/**
+ * Return a copy of the manifest with `id` inserted after `$schema` (if present)
+ * and before `name`. This preserves the conventional field ordering in coati.json.
+ */
+function insertIdIntoManifest(manifest: Manifest, id: string): Manifest {
+	const { $schema, ...rest } = manifest;
+	if ($schema !== undefined) {
+		return { $schema, id, ...rest };
+	}
+	return { id, ...rest };
+}
+
 interface SetupResponse {
 	id: string;
 	slug: string;
@@ -108,7 +120,7 @@ export function registerPublish(program: Command, ctx: CommandContext): void {
 
 			const owner = config.username!;
 
-			// Check for setup.json; auto-run init if absent
+			// Check for coati.json; auto-run init if absent
 			const manifestPath = path.join(cwd, MANIFEST_FILENAME);
 			if (!ctx.fs.existsSync(manifestPath)) {
 				if (ctx.io.isJson()) {
@@ -132,12 +144,12 @@ export function registerPublish(program: Command, ctx: CommandContext): void {
 				ctx.io.print('');
 			}
 
-			// Read and validate setup.json
+			// Read and validate coati.json
 			let manifest;
 			try {
 				manifest = readManifest(cwd);
 			} catch (e) {
-				ctx.io.error(e instanceof Error ? e.message : 'Failed to read setup.json.');
+				ctx.io.error(e instanceof Error ? e.message : 'Failed to read coati.json.');
 				process.exit(1);
 				return;
 			}
@@ -176,24 +188,7 @@ export function registerPublish(program: Command, ctx: CommandContext): void {
 				});
 			}
 
-			const slug = manifest.name;
-
-			// Determine create vs update: check if setup exists
-			let setupExists = false;
-			try {
-				await ctx.api.get(`/setups/${owner}/${slug}`);
-				setupExists = true;
-			} catch (e) {
-				if (e instanceof ApiError && e.status === 404) {
-					setupExists = false;
-				} else if (e instanceof Error) {
-					ctx.io.error(`Failed to check setup: ${e.message}`);
-					process.exit(1);
-					return;
-				}
-			}
-
-			// Build payload
+			// Build payload (excludes id, version, and clone-tracking fields)
 			const payload = {
 				name: manifest.name,
 				slug: manifest.name,
@@ -205,20 +200,32 @@ export function registerPublish(program: Command, ctx: CommandContext): void {
 				files: filesPayload
 			};
 
+			const isUpdate = !!manifest.id;
+
 			if (!ctx.io.isJson()) {
-				ctx.io.print(`${setupExists ? 'Updating' : 'Publishing'} ${owner}/${slug}...`);
+				ctx.io.print(`${isUpdate ? 'Updating' : 'Publishing'} ${owner}/${manifest.name}...`);
 			}
 
 			let result: SetupResponse;
 			try {
-				if (setupExists) {
-					result = await ctx.api.patch<SetupResponse>(`/setups/${owner}/${slug}`, payload);
-				} else {
+				if (!isUpdate) {
+					// First publish: create via POST, then write id back to coati.json
 					result = await ctx.api.post<SetupResponse>(`/setups`, payload);
+					const updatedManifest = insertIdIntoManifest(manifest, result.id);
+					writeManifest(cwd, updatedManifest);
+				} else {
+					// Subsequent publish: update by UUID
+					result = await ctx.api.patch<SetupResponse>(`/setups/${manifest.id}`, payload);
 				}
 			} catch (e) {
 				if (e instanceof ApiError) {
-					if (e.status === 401 || e.status === 403) {
+					if (isUpdate && e.status === 404) {
+						ctx.io.error(
+							'Setup with this ID no longer exists. Remove `id` from coati.json to publish as new.'
+						);
+					} else if (isUpdate && e.status === 403) {
+						ctx.io.error("You don't own the setup with this ID.");
+					} else if (e.status === 401 || e.status === 403) {
 						ctx.io.error('Authentication failed. Run `coati login` to re-authenticate.');
 					} else if (e.status === 409 && e.code === 'SLUG_TAKEN') {
 						ctx.io.error('A setup with this slug already exists. Choose a different name or slug.');
@@ -227,7 +234,7 @@ export function registerPublish(program: Command, ctx: CommandContext): void {
 					} else if (e.status === 500) {
 						ctx.io.error('Server error. Please try again later.');
 					} else {
-						ctx.io.error(`Failed to ${setupExists ? 'update' : 'publish'} setup: ${e.message}`);
+						ctx.io.error(`Failed to ${isUpdate ? 'update' : 'publish'} setup: ${e.message}`);
 					}
 				} else if (e instanceof Error) {
 					if (
@@ -238,7 +245,7 @@ export function registerPublish(program: Command, ctx: CommandContext): void {
 					) {
 						ctx.io.error('Could not reach the Coati API. Check your internet connection.');
 					} else {
-						ctx.io.error(`Failed to ${setupExists ? 'update' : 'publish'} setup: ${e.message}`);
+						ctx.io.error(`Failed to ${isUpdate ? 'update' : 'publish'} setup: ${e.message}`);
 					}
 				} else {
 					ctx.io.error('An unexpected error occurred.');
@@ -252,14 +259,14 @@ export function registerPublish(program: Command, ctx: CommandContext): void {
 
 			if (ctx.io.isJson()) {
 				ctx.io.json({
-					action: setupExists ? 'updated' : 'created',
+					action: isUpdate ? 'updated' : 'created',
 					owner,
 					slug: result.slug,
 					url: setupUrl
 				});
 			} else {
 				ctx.io.print('');
-				ctx.io.success(`Setup ${setupExists ? 'updated' : 'published'} successfully.`);
+				ctx.io.success(`Setup ${isUpdate ? 'updated' : 'published'} successfully.`);
 				ctx.io.print(`  ${setupUrl}`);
 			}
 		});

--- a/cli/src/manifest.ts
+++ b/cli/src/manifest.ts
@@ -31,6 +31,10 @@ export interface ManifestFileEntry {
 
 export interface Manifest {
 	$schema?: string;
+	/** UUID assigned by the server on first publish. Written back to coati.json automatically. */
+	id?: string;
+	/** UUID of the upstream setup this was cloned from. Written by `coati clone`. */
+	sourceId?: string;
 	name: string;
 	version: string;
 	description: string;

--- a/cli/src/validation.ts
+++ b/cli/src/validation.ts
@@ -30,6 +30,8 @@ export const manifestFileEntrySchema = z.object({
 
 export const manifestSchema = z.object({
 	$schema: z.string().optional(),
+	id: z.string().uuid().optional(),
+	sourceId: z.string().uuid().optional(),
 	name: z
 		.string()
 		.min(1, 'Required, must be a non-empty string')

--- a/drizzle/0015_setup_slug_redirects.sql
+++ b/drizzle/0015_setup_slug_redirects.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "setup_slug_redirects" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"old_slug" varchar(100) NOT NULL,
+	"setup_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "setup_slug_redirects" ADD CONSTRAINT "setup_slug_redirects_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "setup_slug_redirects" ADD CONSTRAINT "setup_slug_redirects_setup_id_setups_id_fk" FOREIGN KEY ("setup_id") REFERENCES "public"."setups"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "setup_slug_redirects_user_id_old_slug_idx" ON "setup_slug_redirects" USING btree ("user_id","old_slug");--> statement-breakpoint
+CREATE INDEX "setup_slug_redirects_setup_id_idx" ON "setup_slug_redirects" USING btree ("setup_id");

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -328,6 +328,25 @@ export const setupReports = pgTable(
 	]
 );
 
+export const setupSlugRedirects = pgTable(
+	'setup_slug_redirects',
+	{
+		id: uuid('id').defaultRandom().primaryKey(),
+		userId: uuid('user_id')
+			.references(() => users.id, { onDelete: 'cascade' })
+			.notNull(),
+		oldSlug: varchar('old_slug', { length: 100 }).notNull(),
+		setupId: uuid('setup_id')
+			.references(() => setups.id, { onDelete: 'cascade' })
+			.notNull(),
+		createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull()
+	},
+	(table) => [
+		uniqueIndex('setup_slug_redirects_user_id_old_slug_idx').on(table.userId, table.oldSlug),
+		index('setup_slug_redirects_setup_id_idx').on(table.setupId)
+	]
+);
+
 // ─── Relations ──────────────────────────────────────────────────────────────
 
 export const usersRelations = relations(users, ({ many }) => ({
@@ -475,3 +494,6 @@ export type NewFeedbackSubmission = typeof feedbackSubmissions.$inferInsert;
 
 export type SetupReport = typeof setupReports.$inferSelect;
 export type NewSetupReport = typeof setupReports.$inferInsert;
+
+export type SetupSlugRedirect = typeof setupSlugRedirects.$inferSelect;
+export type NewSetupSlugRedirect = typeof setupSlugRedirects.$inferInsert;

--- a/src/lib/server/queries/setupRepository.ts
+++ b/src/lib/server/queries/setupRepository.ts
@@ -14,7 +14,8 @@ import {
 	recordClone,
 	searchSetups,
 	getAllAgentsWithSetupCount,
-	getAgentBySlugWithSetups
+	getAgentBySlugWithSetups,
+	getSlugRedirect
 } from '$lib/server/queries/setups';
 
 export type SetupListItem = NonNullable<Awaited<ReturnType<typeof getSetupByOwnerSlug>>>;
@@ -99,5 +100,9 @@ export const setupRepo = {
 
 	async getAgentBySlug(slug: string) {
 		return getAgentBySlugWithSetups(slug);
+	},
+
+	async getSlugRedirect(ownerUsername: string, oldSlug: string): Promise<string | null> {
+		return getSlugRedirect(ownerUsername, oldSlug);
 	}
 };

--- a/src/lib/server/queries/setups.ts
+++ b/src/lib/server/queries/setups.ts
@@ -7,6 +7,7 @@ import {
 	setupFiles,
 	setupTags,
 	setupAgents,
+	setupSlugRedirects,
 	tags,
 	agents,
 	stars,
@@ -535,6 +536,107 @@ export async function searchSetups(filters: {
 		pageSize: PAGE_SIZE,
 		totalPages: Math.ceil(total / PAGE_SIZE)
 	};
+}
+
+function slugFromName(name: string): string {
+	return name
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-|-$/g, '');
+}
+
+export async function getSetupByIdWithOwner(id: string) {
+	const result = await db
+		.select({
+			id: setups.id,
+			userId: setups.userId,
+			name: setups.name,
+			slug: setups.slug,
+			description: setups.description,
+			readme: setups.readme,
+			placement: setups.placement,
+			category: setups.category,
+			license: setups.license,
+			minToolVersion: setups.minToolVersion,
+			postInstall: setups.postInstall,
+			prerequisites: setups.prerequisites,
+			starsCount: setups.starsCount,
+			clonesCount: setups.clonesCount,
+			commentsCount: setups.commentsCount,
+			featuredAt: setups.featuredAt,
+			createdAt: setups.createdAt,
+			updatedAt: setups.updatedAt,
+			ownerUsername: users.username
+		})
+		.from(setups)
+		.innerJoin(users, eq(setups.userId, users.id))
+		.where(eq(setups.id, id))
+		.limit(1);
+	return result[0] ?? null;
+}
+
+export async function updateSetupByIdWithSlugRedirects(
+	id: string,
+	data: UpdateSetupInput,
+	context: { userId: string; currentSlug: string }
+) {
+	return db.transaction(async (tx) => {
+		const newSlug = data.name !== undefined ? slugFromName(data.name) : undefined;
+		const slugChanged = newSlug !== undefined && newSlug !== context.currentSlug;
+
+		const updateFields = {
+			...(data.name !== undefined && { name: data.name }),
+			...(slugChanged && { slug: newSlug }),
+			...(data.description !== undefined && { description: data.description }),
+			...(data.readme !== undefined && { readme: data.readme }),
+			...(data.placement !== undefined && { placement: data.placement }),
+			...(data.category !== undefined && { category: data.category }),
+			...(data.license !== undefined && { license: data.license }),
+			...(data.minToolVersion !== undefined && { minToolVersion: data.minToolVersion }),
+			...(data.postInstall !== undefined && { postInstall: data.postInstall }),
+			...(data.prerequisites !== undefined && { prerequisites: data.prerequisites }),
+			updatedAt: new Date()
+		};
+
+		const [setup] = await tx.update(setups).set(updateFields).where(eq(setups.id, id)).returning();
+
+		if (data.files !== undefined) {
+			const name = data.name ?? setup.name;
+			const description = data.description ?? setup.description;
+			const filePaths = data.files.map((f) => f.path);
+			await tx
+				.update(setups)
+				.set({ readme: generateReadme(name, description, filePaths) })
+				.where(eq(setups.id, id));
+
+			await tx.delete(setupFiles).where(eq(setupFiles.setupId, id));
+			if (data.files.length > 0) {
+				await tx.insert(setupFiles).values(toSetupFileRows(id, data.files));
+			}
+		}
+
+		if (slugChanged && newSlug !== undefined) {
+			// Insert the old slug as a redirect
+			await tx
+				.insert(setupSlugRedirects)
+				.values({
+					userId: context.userId,
+					oldSlug: context.currentSlug,
+					setupId: id
+				})
+				.onConflictDoNothing();
+
+			// Flatten chains: update all existing redirects for this setup to point to the new slug
+			// (but don't update the one we just inserted — it's already correct)
+			// Actually we want to ensure all old redirects still exist, just no chains form
+			// The old redirects still point to the same setupId, so no chain exists.
+			// "Flatten chains" means: if there were A→B→C redirects, after renaming to C
+			// we want A→C (not A→B→C). Since redirects store oldSlug→setupId (not oldSlug→newSlug),
+			// there are no chains at the DB level. All redirects resolve directly to the setup by UUID.
+		}
+
+		return setup;
+	});
 }
 
 export async function recordClone(setupId: string): Promise<void> {

--- a/src/lib/server/queries/setups.ts
+++ b/src/lib/server/queries/setups.ts
@@ -79,6 +79,20 @@ export async function getSetupByOwnerSlug(ownerUsername: string, slug: string) {
 	return result[0] ?? null;
 }
 
+export async function getSlugRedirect(
+	ownerUsername: string,
+	oldSlug: string
+): Promise<string | null> {
+	const result = await db
+		.select({ currentSlug: setups.slug })
+		.from(setupSlugRedirects)
+		.innerJoin(users, eq(setupSlugRedirects.userId, users.id))
+		.innerJoin(setups, eq(setupSlugRedirects.setupId, setups.id))
+		.where(and(eq(users.username, ownerUsername), eq(setupSlugRedirects.oldSlug, oldSlug)))
+		.limit(1);
+	return result[0]?.currentSlug ?? null;
+}
+
 export async function getSetupById(id: string) {
 	const result = await db
 		.select({

--- a/src/routes/(public)/[username]/[slug]/+page.server.ts
+++ b/src/routes/(public)/[username]/[slug]/+page.server.ts
@@ -20,7 +20,11 @@ import { isUniqueViolation } from '$lib/server/responses';
 
 export const load: PageServerLoad = async ({ params, locals }) => {
 	const detail = await setupRepo.getDetail(params.username, params.slug, locals.user?.id);
-	if (!detail) throw error(404, 'Setup not found');
+	if (!detail) {
+		const currentSlug = await setupRepo.getSlugRedirect(params.username, params.slug);
+		if (currentSlug) throw redirect(301, `/${params.username}/${currentSlug}`);
+		throw error(404, 'Setup not found');
+	}
 
 	const { files } = detail;
 

--- a/src/routes/api/v1/setups/[id]/+server.ts
+++ b/src/routes/api/v1/setups/[id]/+server.ts
@@ -1,0 +1,38 @@
+import type { RequestHandler } from './$types';
+import { requireApiAuth } from '$lib/server/guards';
+import { success, error, isUniqueViolation, parseRequestBody } from '$lib/server/responses';
+import { updateSetupSchema } from '$lib/types';
+import {
+	getSetupByIdWithOwner,
+	updateSetupByIdWithSlugRedirects
+} from '$lib/server/queries/setups';
+
+export const PATCH: RequestHandler = async (event) => {
+	const authResult = requireApiAuth(event);
+	if (authResult instanceof Response) return authResult;
+	const user = authResult;
+
+	const setup = await getSetupByIdWithOwner(event.params.id);
+	if (!setup) {
+		return error('Setup not found', 'NOT_FOUND', 404);
+	}
+	if (setup.userId !== user.id) {
+		return error('You do not own this setup', 'FORBIDDEN', 403);
+	}
+
+	const parsed = await parseRequestBody(event.request, updateSetupSchema);
+	if (parsed instanceof Response) return parsed;
+
+	try {
+		const updated = await updateSetupByIdWithSlugRedirects(event.params.id, parsed, {
+			userId: user.id,
+			currentSlug: setup.slug
+		});
+		return success({ ...updated, ownerUsername: setup.ownerUsername });
+	} catch (err: unknown) {
+		if (isUniqueViolation(err)) {
+			return error('A setup with this slug already exists', 'SLUG_TAKEN', 409);
+		}
+		throw err;
+	}
+};

--- a/src/routes/api/v1/setups/[id]/setup-id.test.ts
+++ b/src/routes/api/v1/setups/[id]/setup-id.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetSetupByIdWithOwner = vi.fn();
+const mockUpdateSetupByIdWithSlugRedirects = vi.fn();
+
+vi.mock('$lib/server/queries/setups', () => ({
+	getSetupByIdWithOwner: (...args: unknown[]) => mockGetSetupByIdWithOwner(...args),
+	updateSetupByIdWithSlugRedirects: (...args: unknown[]) =>
+		mockUpdateSetupByIdWithSlugRedirects(...args)
+}));
+
+vi.mock('$lib/server/responses', async (importOriginal) => {
+	return await importOriginal();
+});
+
+vi.mock('$lib/server/guards', () => ({
+	requireApiAuth: vi.fn()
+}));
+
+const MOCK_USER = { id: 'user-uuid-1', username: 'alice' };
+const MOCK_SETUP = {
+	id: 'setup-uuid-1',
+	userId: 'user-uuid-1',
+	name: 'My Setup',
+	slug: 'my-setup',
+	description: 'A great setup',
+	readme: null,
+	placement: 'project',
+	category: null,
+	license: null,
+	minToolVersion: null,
+	postInstall: null,
+	prerequisites: null,
+	starsCount: 0,
+	clonesCount: 0,
+	commentsCount: 0,
+	featuredAt: null,
+	createdAt: new Date('2026-01-01'),
+	updatedAt: new Date('2026-01-01'),
+	ownerUsername: 'alice'
+};
+
+function makePatchEvent(id: string, body: unknown, overrideParams?: Record<string, string>) {
+	return {
+		params: overrideParams ?? { id },
+		request: new Request(`http://localhost/api/v1/setups/${id}`, {
+			method: 'PATCH',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(body)
+		}),
+		locals: {}
+	} as Parameters<(typeof import('./+server'))['PATCH']>[0];
+}
+
+describe('PATCH /api/v1/setups/[id]', () => {
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		const { requireApiAuth } = await import('$lib/server/guards');
+		vi.mocked(requireApiAuth).mockReturnValue(MOCK_USER as never);
+	});
+
+	it('returns 401 when not authenticated', async () => {
+		const { requireApiAuth } = await import('$lib/server/guards');
+		vi.mocked(requireApiAuth).mockReturnValue(
+			new Response(JSON.stringify({ error: 'Authentication required', code: 'UNAUTHORIZED' }), {
+				status: 401,
+				headers: { 'Content-Type': 'application/json' }
+			})
+		);
+		const { PATCH } = await import('./+server');
+		const res = await PATCH(makePatchEvent('setup-uuid-1', { description: 'Updated' }));
+		expect(res.status).toBe(401);
+	});
+
+	it('returns 404 when setup not found', async () => {
+		mockGetSetupByIdWithOwner.mockResolvedValue(null);
+		const { PATCH } = await import('./+server');
+		const res = await PATCH(makePatchEvent('nonexistent-uuid', { description: 'Updated' }));
+		expect(res.status).toBe(404);
+		const body = await res.json();
+		expect(body.code).toBe('NOT_FOUND');
+	});
+
+	it('returns 403 when authenticated user does not own the setup', async () => {
+		mockGetSetupByIdWithOwner.mockResolvedValue({
+			...MOCK_SETUP,
+			userId: 'other-user-uuid',
+			ownerUsername: 'bob'
+		});
+		const { PATCH } = await import('./+server');
+		const res = await PATCH(makePatchEvent('setup-uuid-1', { description: 'Updated' }));
+		expect(res.status).toBe(403);
+		const body = await res.json();
+		expect(body.code).toBe('FORBIDDEN');
+	});
+
+	it('returns 200 with updated setup on successful update', async () => {
+		mockGetSetupByIdWithOwner.mockResolvedValue(MOCK_SETUP);
+		const updatedSetup = { ...MOCK_SETUP, description: 'Updated description' };
+		mockUpdateSetupByIdWithSlugRedirects.mockResolvedValue(updatedSetup);
+
+		const { PATCH } = await import('./+server');
+		const res = await PATCH(makePatchEvent('setup-uuid-1', { description: 'Updated description' }));
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.description).toBe('Updated description');
+		expect(body.data.ownerUsername).toBe('alice');
+	});
+
+	it('returns 400 when body is invalid JSON', async () => {
+		mockGetSetupByIdWithOwner.mockResolvedValue(MOCK_SETUP);
+		const event = {
+			params: { id: 'setup-uuid-1' },
+			request: new Request('http://localhost/api/v1/setups/setup-uuid-1', {
+				method: 'PATCH',
+				headers: { 'Content-Type': 'application/json' },
+				body: 'not-json'
+			}),
+			locals: {}
+		} as Parameters<(typeof import('./+server'))['PATCH']>[0];
+		const { PATCH } = await import('./+server');
+		const res = await PATCH(event);
+		expect(res.status).toBe(400);
+	});
+
+	it('calls updateSetupByIdWithSlugRedirects with correct arguments', async () => {
+		mockGetSetupByIdWithOwner.mockResolvedValue(MOCK_SETUP);
+		const updatedSetup = { ...MOCK_SETUP, name: 'New Name', slug: 'new-name' };
+		mockUpdateSetupByIdWithSlugRedirects.mockResolvedValue(updatedSetup);
+
+		const { PATCH } = await import('./+server');
+		await PATCH(makePatchEvent('setup-uuid-1', { name: 'New Name' }));
+
+		expect(mockUpdateSetupByIdWithSlugRedirects).toHaveBeenCalledWith(
+			'setup-uuid-1',
+			expect.objectContaining({ name: 'New Name' }),
+			expect.objectContaining({
+				userId: 'user-uuid-1',
+				currentSlug: 'my-setup'
+			})
+		);
+	});
+
+	it('returns updated setup including current slug and ownerUsername', async () => {
+		mockGetSetupByIdWithOwner.mockResolvedValue(MOCK_SETUP);
+		const updatedSetup = { ...MOCK_SETUP, name: 'Renamed Setup', slug: 'renamed-setup' };
+		mockUpdateSetupByIdWithSlugRedirects.mockResolvedValue(updatedSetup);
+
+		const { PATCH } = await import('./+server');
+		const res = await PATCH(makePatchEvent('setup-uuid-1', { name: 'Renamed Setup' }));
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.slug).toBe('renamed-setup');
+		expect(body.data.ownerUsername).toBe('alice');
+	});
+
+	it('returns 409 when slug already taken', async () => {
+		mockGetSetupByIdWithOwner.mockResolvedValue(MOCK_SETUP);
+		const uniqueViolationError = Object.assign(new Error('unique violation'), { code: '23505' });
+		mockUpdateSetupByIdWithSlugRedirects.mockRejectedValue(uniqueViolationError);
+
+		const { PATCH } = await import('./+server');
+		const res = await PATCH(makePatchEvent('setup-uuid-1', { name: 'Taken Name' }));
+		expect(res.status).toBe(409);
+		const body = await res.json();
+		expect(body.code).toBe('SLUG_TAKEN');
+	});
+});

--- a/src/routes/api/v1/setups/[owner]/[slug]/+server.ts
+++ b/src/routes/api/v1/setups/[owner]/[slug]/+server.ts
@@ -7,6 +7,13 @@ import { setupRepo } from '$lib/server/queries/setupRepository';
 export const GET: RequestHandler = async ({ params }) => {
 	const setup = await setupRepo.getByOwnerSlug(params.owner, params.slug);
 	if (!setup) {
+		const currentSlug = await setupRepo.getSlugRedirect(params.owner, params.slug);
+		if (currentSlug) {
+			return new Response(null, {
+				status: 301,
+				headers: { Location: `/api/v1/setups/${params.owner}/${currentSlug}` }
+			});
+		}
 		return error('Setup not found', 'NOT_FOUND', 404);
 	}
 	return success(setup);

--- a/src/routes/api/v1/setups/[owner]/[slug]/owner-slug.test.ts
+++ b/src/routes/api/v1/setups/[owner]/[slug]/owner-slug.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetByOwnerSlug = vi.fn();
+const mockGetSlugRedirect = vi.fn();
+
+vi.mock('$lib/server/queries/setupRepository', () => ({
+	setupRepo: {
+		getByOwnerSlug: (...args: unknown[]) => mockGetByOwnerSlug(...args),
+		getSlugRedirect: (...args: unknown[]) => mockGetSlugRedirect(...args)
+	}
+}));
+
+vi.mock('$lib/server/responses', async (importOriginal) => {
+	return await importOriginal();
+});
+
+vi.mock('$lib/server/guards', () => ({
+	requireApiAuth: vi.fn()
+}));
+
+const MOCK_SETUP = {
+	id: 'setup-uuid-1',
+	userId: 'user-uuid-1',
+	name: 'My Setup',
+	slug: 'my-setup',
+	description: 'A great setup',
+	readme: null,
+	placement: 'project',
+	category: null,
+	license: null,
+	minToolVersion: null,
+	postInstall: null,
+	prerequisites: null,
+	starsCount: 0,
+	clonesCount: 0,
+	commentsCount: 0,
+	featuredAt: null,
+	createdAt: new Date('2026-01-01'),
+	updatedAt: new Date('2026-01-01'),
+	ownerUsername: 'alice',
+	ownerAvatarUrl: null
+};
+
+function makeGetEvent(owner: string, slug: string) {
+	return {
+		params: { owner, slug },
+		request: new Request(`http://localhost/api/v1/setups/${owner}/${slug}`)
+	} as Parameters<(typeof import('./+server'))['GET']>[0];
+}
+
+describe('GET /api/v1/setups/[owner]/[slug]', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('returns 200 with setup when found by slug', async () => {
+		mockGetByOwnerSlug.mockResolvedValue(MOCK_SETUP);
+		const { GET } = await import('./+server');
+		const res = await GET(makeGetEvent('alice', 'my-setup'));
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.slug).toBe('my-setup');
+	});
+
+	it('returns 301 redirect to current slug when old slug found in redirects', async () => {
+		mockGetByOwnerSlug.mockResolvedValue(null);
+		mockGetSlugRedirect.mockResolvedValue('renamed-setup');
+		const { GET } = await import('./+server');
+		const res = await GET(makeGetEvent('alice', 'old-slug'));
+		expect(res.status).toBe(301);
+		expect(res.headers.get('Location')).toBe('/api/v1/setups/alice/renamed-setup');
+	});
+
+	it('returns 404 when slug not found in setups or redirects', async () => {
+		mockGetByOwnerSlug.mockResolvedValue(null);
+		mockGetSlugRedirect.mockResolvedValue(null);
+		const { GET } = await import('./+server');
+		const res = await GET(makeGetEvent('alice', 'nonexistent'));
+		expect(res.status).toBe(404);
+		const body = await res.json();
+		expect(body.code).toBe('NOT_FOUND');
+	});
+
+	it('redirect Location points directly to current slug (no chains)', async () => {
+		mockGetByOwnerSlug.mockResolvedValue(null);
+		mockGetSlugRedirect.mockResolvedValue('current-slug');
+		const { GET } = await import('./+server');
+		const res = await GET(makeGetEvent('alice', 'first-old-slug'));
+		expect(res.status).toBe(301);
+		expect(res.headers.get('Location')).toBe('/api/v1/setups/alice/current-slug');
+	});
+});


### PR DESCRIPTION
## Summary

- feat(api): add PATCH /api/v1/setups/{id} endpoint with ownership check and slug redirects (#218)
- feat(cli): update publish command to use ID-based create/update flow (#221)
- feat(api): add slug redirect resolution on GET routes (#220)
- feat(cli): update clone command to write sourceId and refresh source on re-clone (#219)

Closes #215
Closes #216
Closes #217
Closes #218
Closes #219
Closes #220
Closes #221

## Test plan

See individual issue acceptance criteria for testing details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)