### PR TITLE
test(cli): add edge-case tests for large dirs, symlinks, and permissions (#247)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@coati/sh",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"description": "Coati CLI — clone, publish, and manage AI coding setups",
 	"type": "module",
 	"main": "dist/index.js",

--- a/cli/src/detector.test.ts
+++ b/cli/src/detector.test.ts
@@ -551,6 +551,89 @@ describe('detectFiles — multi-agent projects', () => {
 	});
 });
 
+// ─── Edge cases ───────────────────────────────────────────────────────────────
+
+describe('detectFiles — large directory with deep irrelevant trees', () => {
+	it('detects all agent configs alongside 50+ level deep irrelevant trees', () => {
+		// Agent config files in known locations
+		mkfile('CLAUDE.md', '# claude instructions');
+		mkfile('.claude/commands/review.md', '# review');
+		mkfile('AGENTS.md', '# agents');
+		mkfile('.cursor/rules/style.mdc', '# cursor rules');
+
+		// Build a 52-level deep irrelevant directory path
+		const levels = 52;
+		const deepSegments = Array.from({ length: levels }, (_, i) => `d${i}`);
+		const deepPath = `fake-deep/${deepSegments.join('/')}`;
+
+		// Place decoy files deep inside — they should NOT be detected
+		mkfile(`${deepPath}/CLAUDE.md`, '# decoy - should not be detected');
+		mkfile(`${deepPath}/AGENTS.md`, '# decoy - should not be detected');
+
+		// Another irrelevant tree
+		mkfile('Library/Application Support/deep/path/CLAUDE.md', '# decoy');
+
+		const files = detectFiles(tmpDir);
+
+		// All real agent configs are detected
+		expect(find(files, 'CLAUDE.md')).toBeDefined();
+		expect(find(files, '.claude/commands/review.md')).toBeDefined();
+		expect(find(files, 'AGENTS.md')).toBeDefined();
+
+		// Decoy files in irrelevant trees are NOT detected
+		const paths = files.map((f) => f.path);
+		expect(paths.some((p) => p.startsWith('fake-deep/'))).toBe(false);
+		expect(paths.some((p) => p.startsWith('Library/'))).toBe(false);
+	});
+});
+
+describe('detectFiles — symlink loop', () => {
+	it('completes without hanging when a symlink loop exists inside a scan target', () => {
+		mkfile('.claude/commands/review.md', '# review');
+
+		// Create a symlink loop: .claude/loop -> .claude (circular reference)
+		const claudeDir = path.join(tmpDir, '.claude');
+		fs.symlinkSync(claudeDir, path.join(claudeDir, 'loop'));
+
+		// Should complete without hanging or throwing
+		let files: DetectedFile[] = [];
+		expect(() => {
+			files = detectFiles(tmpDir);
+		}).not.toThrow();
+
+		// Real file should still be detected
+		expect(find(files, '.claude/commands/review.md')).toBeDefined();
+	});
+});
+
+describe('detectFiles — permission error', () => {
+	it.skipIf(process.getuid?.() === 0)(
+		'skips unreadable directories and still returns results from accessible ones',
+		() => {
+			mkfile('CLAUDE.md', '# claude');
+			mkfile('.cursor/rules/style.mdc', '# cursor rules');
+
+			// Create a known scan-target directory with no read permissions
+			const restrictedDir = path.join(tmpDir, '.gemini');
+			fs.mkdirSync(restrictedDir, { recursive: true });
+			fs.chmodSync(restrictedDir, 0o000);
+
+			try {
+				// Scanner must not throw
+				expect(() => detectFiles(tmpDir)).not.toThrow();
+
+				// Files from accessible locations are still returned
+				const files = detectFiles(tmpDir);
+				expect(find(files, 'CLAUDE.md')).toBeDefined();
+				expect(findAll(files, '.cursor/rules/style.mdc').length).toBeGreaterThanOrEqual(1);
+			} finally {
+				// Restore permissions so afterEach cleanup can delete the directory
+				fs.chmodSync(restrictedDir, 0o755);
+			}
+		}
+	);
+});
+
 // ─── Description field ────────────────────────────────────────────────────────
 
 describe('detectFiles — description field', () => {

--- a/cli/src/detector.ts
+++ b/cli/src/detector.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { AGENTS, matchesGlob } from '@coati/agents-registry';
+import { AGENTS, matchesGlob, type AgentDefinition } from '@coati/agents-registry';
 import type { ManifestComponentType } from './manifest.js';
 
 export interface DetectedFile {
@@ -11,7 +11,7 @@ export interface DetectedFile {
 	description: string;
 }
 
-/** Directories to skip during recursive scanning. */
+/** Directories to skip during scanning (safety net). */
 const SKIP_DIRS = new Set([
 	'node_modules',
 	'.git',
@@ -25,24 +25,82 @@ const SKIP_DIRS = new Set([
 	'venv'
 ]);
 
-function walkDir(dir: string, baseDir: string): string[] {
-	const results: string[] = [];
-	let entries: fs.Dirent[];
-	try {
-		entries = fs.readdirSync(dir, { withFileTypes: true });
-	} catch {
-		return results;
-	}
-	for (const entry of entries) {
-		if (SKIP_DIRS.has(entry.name)) continue;
-		const fullPath = path.join(dir, entry.name);
-		if (entry.isDirectory()) {
-			results.push(...walkDir(fullPath, baseDir));
-		} else if (entry.isFile()) {
-			// Normalize to forward slashes for cross-platform pattern matching
-			results.push(path.relative(baseDir, fullPath).split(path.sep).join('/'));
+/**
+ * Extract scan targets from the AGENTS registry.
+ *
+ * Returns:
+ * - `rootFileGlobs`: globs with no directory component (e.g. "CLAUDE.md", ".mcp.json")
+ *   — these are checked via direct `fs.existsSync` rather than directory walking.
+ * - `dirPrefixes`: the first path segment of every directory-based glob
+ *   (e.g. ".claude", ".cursor", ".config") — only these dirs are entered at the top level.
+ */
+function extractScanTargets(agents: AgentDefinition[]): {
+	rootFileGlobs: string[];
+	dirPrefixes: Set<string>;
+} {
+	const rootFileGlobs: string[] = [];
+	const dirPrefixes = new Set<string>();
+
+	for (const agent of agents) {
+		for (const list of [agent.projectGlobs, agent.globalGlobs]) {
+			for (const { glob } of list) {
+				const slashIdx = glob.indexOf('/');
+				if (slashIdx === -1) {
+					// No directory component → root-level file pattern
+					if (!rootFileGlobs.includes(glob)) {
+						rootFileGlobs.push(glob);
+					}
+				} else {
+					// Has directory component → extract first path segment
+					dirPrefixes.add(glob.slice(0, slashIdx));
+				}
+			}
 		}
 	}
+
+	return { rootFileGlobs, dirPrefixes };
+}
+
+/**
+ * Iterative BFS directory walker.
+ *
+ * At the top level (`baseDir`), only enters directories whose name is in `dirPrefixes`.
+ * Once inside a target directory, walks all subdirectories normally.
+ * Skips symlinks, retains SKIP_DIRS as a safety net, and handles EACCES/EPERM gracefully.
+ */
+function collectDirFiles(baseDir: string, dirPrefixes: Set<string>): string[] {
+	const results: string[] = [];
+	// Queue entries: [absoluteDirPath, isTopLevel]
+	const queue: Array<[string, boolean]> = [[baseDir, true]];
+
+	while (queue.length > 0) {
+		const [currentDir, isTopLevel] = queue.shift()!;
+
+		let entries: fs.Dirent[];
+		try {
+			entries = fs.readdirSync(currentDir, { withFileTypes: true });
+		} catch {
+			// Gracefully skip unreadable directories (EACCES, EPERM, etc.)
+			continue;
+		}
+
+		for (const entry of entries) {
+			if (entry.isSymbolicLink()) continue;
+			if (SKIP_DIRS.has(entry.name)) continue;
+
+			const fullPath = path.join(currentDir, entry.name);
+
+			if (entry.isDirectory()) {
+				// At the top level, only enter directories matching known prefixes
+				if (isTopLevel && !dirPrefixes.has(entry.name)) continue;
+				queue.push([fullPath, false]);
+			} else if (entry.isFile()) {
+				// Normalize to forward slashes for cross-platform pattern matching
+				results.push(path.relative(baseDir, fullPath).split(path.sep).join('/'));
+			}
+		}
+	}
+
 	return results;
 }
 
@@ -79,7 +137,19 @@ function makeDescription(
  * the same agent's project globs (one entry per (file, agent) pair).
  */
 export function detectFiles(dir: string): DetectedFile[] {
-	const allFiles = walkDir(dir, dir);
+	const { rootFileGlobs, dirPrefixes } = extractScanTargets(AGENTS);
+
+	// ── 1. Root-level files: direct existence checks (no walking needed) ─────
+	const allFiles: string[] = [];
+	for (const glob of rootFileGlobs) {
+		if (fs.existsSync(path.join(dir, glob))) {
+			allFiles.push(glob);
+		}
+	}
+
+	// ── 2. Directory-based files: targeted iterative BFS walker ──────────────
+	allFiles.push(...collectDirFiles(dir, dirPrefixes));
+
 	const detected: DetectedFile[] = [];
 
 	for (const relativePath of allFiles) {


### PR DESCRIPTION
## Summary

- test(cli): add edge-case tests for large dirs, symlinks, and permissions (#247)
- fix(cli): replace recursive walkDir with targeted iterative scanner (#246)

Closes #246
Closes #247
Closes #245


## Test plan

See individual issue acceptance criteria for testing details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
