### PR TITLE
feat(ui): add delete setup confirmation UI with owner dropdown (#255)

### DIFF
--- a/coati.json
+++ b/coati.json
@@ -4,13 +4,8 @@
 	"version": "1.0.0",
 	"description": "Second attempt after I forgot to save the old one",
 	"category": "web-dev",
-	"agents": [
-		"claude-code"
-	],
-	"tags": [
-		"coati",
-		"claude-code"
-	],
+	"agents": ["claude-code"],
+	"tags": ["coati", "claude-code"],
 	"files": [
 		{
 			"path": ".claude/skills/tdd/SKILL.md",

--- a/src/lib/components/DeleteSetupDialog.svelte
+++ b/src/lib/components/DeleteSetupDialog.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import {
+		AlertDialog,
+		AlertDialogContent,
+		AlertDialogHeader,
+		AlertDialogFooter,
+		AlertDialogTitle,
+		AlertDialogDescription,
+		AlertDialogCancel
+	} from '$lib/components/ui/alert-dialog';
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
+	import { Label } from '$lib/components/ui/label';
+
+	interface Props {
+		open: boolean;
+		slug: string;
+		setupName: string;
+		onOpenChange: (open: boolean) => void;
+	}
+
+	let { open, slug, setupName, onOpenChange }: Props = $props();
+
+	let slugInput = $state('');
+	let deleting = $state(false);
+
+	const slugMatches = $derived(slugInput === slug);
+
+	function handleOpenChange(value: boolean) {
+		if (!value) {
+			slugInput = '';
+			deleting = false;
+		}
+		onOpenChange(value);
+	}
+</script>
+
+<AlertDialog {open} onOpenChange={handleOpenChange}>
+	<AlertDialogContent>
+		<AlertDialogHeader>
+			<AlertDialogTitle>Delete "{setupName}"?</AlertDialogTitle>
+			<AlertDialogDescription>
+				This action <strong>cannot be undone</strong>. All files, stars, comments, and tags
+				associated with this setup will be permanently deleted.
+			</AlertDialogDescription>
+		</AlertDialogHeader>
+
+		<form
+			method="POST"
+			action="?/delete"
+			use:enhance={() => {
+				deleting = true;
+				return async ({ result, update }) => {
+					deleting = false;
+					if (result.type !== 'redirect') {
+						await update();
+					}
+				};
+			}}
+		>
+			<input type="hidden" name="slug" value={slug} />
+
+			<div class="mb-4 space-y-1.5">
+				<Label for="delete-slug-input">
+					Type <strong>{slug}</strong> to confirm
+				</Label>
+				<Input
+					id="delete-slug-input"
+					type="text"
+					placeholder={slug}
+					bind:value={slugInput}
+					autocomplete="off"
+					data-testid="delete-slug-input"
+				/>
+			</div>
+
+			<AlertDialogFooter>
+				<AlertDialogCancel type="button" onclick={() => handleOpenChange(false)}>
+					Cancel
+				</AlertDialogCancel>
+				<Button
+					type="submit"
+					variant="destructive"
+					disabled={!slugMatches || deleting}
+					data-testid="delete-confirm-btn"
+				>
+					{deleting ? 'Deleting…' : 'Delete setup'}
+				</Button>
+			</AlertDialogFooter>
+		</form>
+	</AlertDialogContent>
+</AlertDialog>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-action.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-action.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+	import { buttonVariants } from '$lib/components/ui/button/button.svelte';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: AlertDialogPrimitive.ActionProps = $props();
+</script>
+
+<AlertDialogPrimitive.Action
+	bind:ref
+	data-slot="alert-dialog-action"
+	class={cn(buttonVariants(), className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-cancel.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-cancel.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+	import { buttonVariants } from '$lib/components/ui/button/button.svelte';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: AlertDialogPrimitive.CancelProps = $props();
+</script>
+
+<AlertDialogPrimitive.Cancel
+	bind:ref
+	data-slot="alert-dialog-cancel"
+	class={cn(buttonVariants({ variant: 'outline' }), className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+	import AlertDialogOverlay from './alert-dialog-overlay.svelte';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: AlertDialogPrimitive.ContentProps = $props();
+</script>
+
+<AlertDialogPrimitive.Portal>
+	<AlertDialogOverlay />
+	<AlertDialogPrimitive.Content
+		bind:ref
+		data-slot="alert-dialog-content"
+		class={cn(
+			'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200',
+			className
+		)}
+		{...restProps}
+	>
+		{@render children?.()}
+	</AlertDialogPrimitive.Content>
+</AlertDialogPrimitive.Portal>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-description.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-description.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: AlertDialogPrimitive.DescriptionProps = $props();
+</script>
+
+<AlertDialogPrimitive.Description
+	bind:ref
+	data-slot="alert-dialog-description"
+	class={cn('text-muted-foreground text-sm', className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-footer.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-footer.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let { class: className, children, ...restProps }: HTMLAttributes<HTMLDivElement> = $props();
+</script>
+
+<div
+	data-slot="alert-dialog-footer"
+	class={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-header.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-header.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	let { class: className, children, ...restProps }: HTMLAttributes<HTMLDivElement> = $props();
+</script>
+
+<div
+	data-slot="alert-dialog-header"
+	class={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-overlay.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-overlay.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: AlertDialogPrimitive.OverlayProps = $props();
+</script>
+
+<AlertDialogPrimitive.Overlay
+	bind:ref
+	data-slot="alert-dialog-overlay"
+	class={cn(
+		'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80',
+		className
+	)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-title.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-title.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: AlertDialogPrimitive.TitleProps = $props();
+</script>
+
+<AlertDialogPrimitive.Title
+	bind:ref
+	data-slot="alert-dialog-title"
+	class={cn('text-lg font-semibold', className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-trigger.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-trigger.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from 'bits-ui';
+
+	let { ref = $bindable(null), ...restProps }: AlertDialogPrimitive.TriggerProps = $props();
+</script>
+
+<AlertDialogPrimitive.Trigger bind:ref data-slot="alert-dialog-trigger" {...restProps} />

--- a/src/lib/components/ui/alert-dialog/alert-dialog.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from 'bits-ui';
+
+	let { ...restProps }: AlertDialogPrimitive.RootProps = $props();
+</script>
+
+<AlertDialogPrimitive.Root {...restProps} />

--- a/src/lib/components/ui/alert-dialog/index.ts
+++ b/src/lib/components/ui/alert-dialog/index.ts
@@ -1,0 +1,34 @@
+import Root from './alert-dialog.svelte';
+import Content from './alert-dialog-content.svelte';
+import Overlay from './alert-dialog-overlay.svelte';
+import Title from './alert-dialog-title.svelte';
+import Description from './alert-dialog-description.svelte';
+import Trigger from './alert-dialog-trigger.svelte';
+import Action from './alert-dialog-action.svelte';
+import Cancel from './alert-dialog-cancel.svelte';
+import Header from './alert-dialog-header.svelte';
+import Footer from './alert-dialog-footer.svelte';
+
+export {
+	Root,
+	Content,
+	Overlay,
+	Title,
+	Description,
+	Trigger,
+	Action,
+	Cancel,
+	Header,
+	Footer,
+	//
+	Root as AlertDialog,
+	Content as AlertDialogContent,
+	Overlay as AlertDialogOverlay,
+	Title as AlertDialogTitle,
+	Description as AlertDialogDescription,
+	Trigger as AlertDialogTrigger,
+	Action as AlertDialogAction,
+	Cancel as AlertDialogCancel,
+	Header as AlertDialogHeader,
+	Footer as AlertDialogFooter
+};

--- a/src/routes/(public)/[username]/+page.svelte
+++ b/src/routes/(public)/[username]/+page.svelte
@@ -2,6 +2,8 @@
 	import { untrack } from 'svelte';
 	import { enhance } from '$app/forms';
 	import { toast } from 'svelte-sonner';
+	import { page } from '$app/stores';
+	import { replaceState } from '$app/navigation';
 	import { Avatar, AvatarImage, AvatarFallback } from '$lib/components/ui/avatar';
 	import { Separator } from '$lib/components/ui/separator';
 	import { Button } from '$lib/components/ui/button';
@@ -47,6 +49,16 @@
 	function tabHref(tab: string) {
 		return `/${data.profile.username}?tab=${tab}`;
 	}
+
+	$effect(() => {
+		const deletedName = $page.url.searchParams.get('deleted');
+		if (deletedName) {
+			toast.success(`Setup "${deletedName}" deleted`);
+			const url = new URL($page.url);
+			url.searchParams.delete('deleted');
+			replaceState(url, $page.state);
+		}
+	});
 </script>
 
 <svelte:head>

--- a/src/routes/(public)/[username]/[slug]/+page.server.ts
+++ b/src/routes/(public)/[username]/[slug]/+page.server.ts
@@ -5,7 +5,8 @@ import {
 	setStar,
 	getSetupByOwnerSlug,
 	isSetupStarredByUser,
-	setFeatured
+	setFeatured,
+	deleteSetup
 } from '$lib/server/queries/setups';
 import {
 	createComment,
@@ -141,6 +142,26 @@ export const actions: Actions = {
 		const nowFeatured = !setup.featuredAt;
 		await setFeatured(setup.id, nowFeatured);
 		return { featured: nowFeatured };
+	},
+
+	delete: async ({ locals, params, request }) => {
+		if (!locals.user) throw redirect(302, '/auth/login/github');
+
+		const setup = await getSetupByOwnerSlug(params.username, params.slug);
+		if (!setup) throw error(404, 'Setup not found');
+
+		if (setup.userId !== locals.user.id) {
+			return fail(403, { error: 'You do not own this setup', code: 'FORBIDDEN' });
+		}
+
+		const formData = await request.formData();
+		const slugConfirmation = String(formData.get('slug') ?? '');
+		if (slugConfirmation !== setup.slug) {
+			return fail(400, { error: 'Slug confirmation does not match', code: 'SLUG_MISMATCH' });
+		}
+
+		await deleteSetup(setup.id, locals.user.id);
+		throw redirect(303, `/${params.username}?deleted=${encodeURIComponent(setup.name)}`);
 	},
 
 	report: async ({ locals, params, request }) => {

--- a/src/routes/(public)/[username]/[slug]/+page.svelte
+++ b/src/routes/(public)/[username]/[slug]/+page.svelte
@@ -1,9 +1,16 @@
 <script lang="ts">
 	import { Avatar, AvatarImage, AvatarFallback } from '$lib/components/ui/avatar';
 	import { Button } from '$lib/components/ui/button';
+	import {
+		DropdownMenu,
+		DropdownMenuContent,
+		DropdownMenuItem,
+		DropdownMenuTrigger
+	} from '$lib/components/ui/dropdown-menu';
 	import StarButton from '$lib/components/StarButton.svelte';
 	import AgentIcon from '$lib/components/AgentIcon.svelte';
 	import OgMeta from '$lib/components/OgMeta.svelte';
+	import DeleteSetupDialog from '$lib/components/DeleteSetupDialog.svelte';
 	import { enhance } from '$app/forms';
 	import { timeAgo } from '$lib/utils';
 
@@ -71,6 +78,8 @@
 			return { agentGroups, sharedCount };
 		})()
 	);
+
+	let deleteDialogOpen = $state(false);
 
 	function copyCloneCommand() {
 		navigator.clipboard.writeText(cloneCommand);
@@ -250,6 +259,46 @@
 						}}
 					/>
 				</div>
+
+				<!-- Owner actions dropdown -->
+				{#if isOwner}
+					<div>
+						<DropdownMenu>
+							<DropdownMenuTrigger>
+								{#snippet child({ props })}
+									<Button
+										variant="outline"
+										size="sm"
+										class="w-full"
+										{...props}
+										data-testid="owner-actions-btn"
+									>
+										Actions
+										<svg
+											class="ml-auto size-4"
+											viewBox="0 0 16 16"
+											fill="currentColor"
+											aria-hidden="true"
+										>
+											<path
+												d="M4.427 7.427l3.396 3.396a.25.25 0 0 0 .354 0l3.396-3.396A.25.25 0 0 0 11.396 7H4.604a.25.25 0 0 0-.177.427Z"
+											/>
+										</svg>
+									</Button>
+								{/snippet}
+							</DropdownMenuTrigger>
+							<DropdownMenuContent align="end" class="w-48">
+								<DropdownMenuItem
+									variant="destructive"
+									onclick={() => (deleteDialogOpen = true)}
+									data-testid="delete-setup-menu-item"
+								>
+									Delete setup
+								</DropdownMenuItem>
+							</DropdownMenuContent>
+						</DropdownMenu>
+					</div>
+				{/if}
 
 				<!-- Admin: featured toggle -->
 				{#if data.user?.isAdmin}
@@ -508,6 +557,16 @@
 			</div>
 		</div>
 	</div>
+
+	<!-- Delete setup confirmation dialog -->
+	{#if isOwner}
+		<DeleteSetupDialog
+			open={deleteDialogOpen}
+			slug={data.setup.slug}
+			setupName={data.setup.name}
+			onOpenChange={(v) => (deleteDialogOpen = v)}
+		/>
+	{/if}
 
 	<!-- BETA: comments hidden, re-enable post-launch -->
 	<!-- <Separator class="my-6 lg:my-8" /> -->

--- a/src/routes/(public)/[username]/[slug]/page.server.test.ts
+++ b/src/routes/(public)/[username]/[slug]/page.server.test.ts
@@ -13,12 +13,14 @@ vi.mock('$lib/server/queries/setupRepository', () => ({
 
 const mockSetFeatured = vi.fn();
 const mockGetSetupByOwnerSlug = vi.fn();
+const mockDeleteSetup = vi.fn();
 
 vi.mock('$lib/server/queries/setups', () => ({
 	setStar: vi.fn(),
 	getSetupByOwnerSlug: (...args: unknown[]) => mockGetSetupByOwnerSlug(...args),
 	isSetupStarredByUser: vi.fn(),
-	setFeatured: (...args: unknown[]) => mockSetFeatured(...args)
+	setFeatured: (...args: unknown[]) => mockSetFeatured(...args),
+	deleteSetup: (...args: unknown[]) => mockDeleteSetup(...args)
 }));
 
 vi.mock('$lib/server/queries/comments', () => ({
@@ -216,6 +218,70 @@ describe('feature action', () => {
 		const result = await actions.feature(event);
 		expect(mockSetFeatured).toHaveBeenCalledWith('setup-id', false);
 		expect(result).toMatchObject({ featured: false });
+	});
+});
+
+describe('delete action', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.resetModules();
+	});
+
+	it('redirects to login when not authenticated', async () => {
+		const { actions } = await import('./+page.server');
+		const event = makeActionEvent({}, { username: 'alice', slug: 'test-setup' }, null);
+		await expect(actions.delete(event)).rejects.toMatchObject({ status: 302 });
+	});
+
+	it('returns 404 when setup not found', async () => {
+		mockGetSetupByOwnerSlug.mockResolvedValue(null);
+		const { actions } = await import('./+page.server');
+		const event = makeActionEvent(
+			{ slug: 'test-setup' },
+			{ username: 'alice', slug: 'test-setup' },
+			{ id: 'owner-id', username: 'alice' }
+		);
+		await expect(actions.delete(event)).rejects.toMatchObject({ status: 404 });
+	});
+
+	it('returns 403 when user does not own the setup', async () => {
+		mockGetSetupByOwnerSlug.mockResolvedValue(MOCK_SETUP);
+		const { actions } = await import('./+page.server');
+		const event = makeActionEvent(
+			{ slug: 'test-setup' },
+			{ username: 'alice', slug: 'test-setup' },
+			{ id: 'other-user-id', username: 'bob' }
+		);
+		const result = await actions.delete(event);
+		expect(result).toMatchObject({ status: 403 });
+	});
+
+	it('returns 400 when slug confirmation does not match', async () => {
+		mockGetSetupByOwnerSlug.mockResolvedValue(MOCK_SETUP);
+		const { actions } = await import('./+page.server');
+		const event = makeActionEvent(
+			{ slug: 'wrong-slug' },
+			{ username: 'alice', slug: 'test-setup' },
+			{ id: 'owner-id', username: 'alice' }
+		);
+		const result = await actions.delete(event);
+		expect(result).toMatchObject({ status: 400 });
+	});
+
+	it('deletes setup and redirects to profile with deleted query param', async () => {
+		mockGetSetupByOwnerSlug.mockResolvedValue(MOCK_SETUP);
+		mockDeleteSetup.mockResolvedValue(1);
+		const { actions } = await import('./+page.server');
+		const event = makeActionEvent(
+			{ slug: 'test-setup' },
+			{ username: 'alice', slug: 'test-setup' },
+			{ id: 'owner-id', username: 'alice' }
+		);
+		await expect(actions.delete(event)).rejects.toMatchObject({
+			status: 303,
+			location: '/alice?deleted=Test%20Setup'
+		});
+		expect(mockDeleteSetup).toHaveBeenCalledWith('setup-id', 'owner-id');
 	});
 });
 


### PR DESCRIPTION
## Summary

- feat(ui): add delete setup confirmation UI with owner dropdown (#255)
- feat(setup): add delete form action to setup detail page (#254)

Closes #254
Closes #255
Closes #253


## Test plan

See individual issue acceptance criteria for testing details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
