### PR TITLE
feat(ui): add GuideNudge popover for first-time users (#266)

### DIFF
--- a/src/lib/components/CodeBlock.svelte
+++ b/src/lib/components/CodeBlock.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+	import { Copy, Check } from '@lucide/svelte';
+
+	interface Props {
+		code: string;
+		language?: string;
+		label?: string;
+	}
+
+	const { code, language, label }: Props = $props();
+
+	let copied = $state(false);
+
+	const headerLabel = $derived(() => {
+		if (label !== undefined) return label;
+		if (language) return language.charAt(0).toUpperCase() + language.slice(1);
+		return '';
+	});
+
+	async function handleCopy() {
+		await navigator.clipboard.writeText(code);
+		copied = true;
+		setTimeout(() => (copied = false), 2000);
+	}
+</script>
+
+<div class="overflow-hidden rounded-lg border border-border bg-muted/50">
+	{#if headerLabel()}
+		<div
+			class="flex items-center justify-between border-b border-border bg-muted px-4 py-2 text-xs text-muted-foreground"
+		>
+			<span class="font-medium">{headerLabel()}</span>
+			<button
+				onclick={handleCopy}
+				class="rounded p-1 transition-colors hover:bg-accent hover:text-foreground"
+				aria-label={copied ? 'Copied!' : 'Copy code'}
+			>
+				{#if copied}
+					<Check class="size-4 text-green-500" />
+				{:else}
+					<Copy class="size-4" />
+				{/if}
+			</button>
+		</div>
+	{:else}
+		<div class="flex justify-end border-b border-border bg-muted px-4 py-2">
+			<button
+				onclick={handleCopy}
+				class="rounded p-1 transition-colors hover:bg-accent hover:text-foreground"
+				aria-label={copied ? 'Copied!' : 'Copy code'}
+			>
+				{#if copied}
+					<Check class="size-4 text-green-500" />
+				{:else}
+					<Copy class="size-4" />
+				{/if}
+			</button>
+		</div>
+	{/if}
+	<pre class="overflow-x-auto p-4 text-sm leading-relaxed text-foreground"><code
+			class={language ? `language-${language}` : ''}>{code}</code
+		></pre>
+</div>

--- a/src/lib/components/CodeBlock.test.ts
+++ b/src/lib/components/CodeBlock.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Pure logic extracted from CodeBlock.svelte for unit testing
+
+/**
+ * Writes code to the clipboard.
+ * Returns the promise from writeText so callers can await it.
+ */
+function copyCode(code: string, clipboard: { writeText: (text: string) => Promise<void> }) {
+	return clipboard.writeText(code);
+}
+
+/**
+ * Schedules a callback after `delay` ms and returns a handle that can be cleared.
+ * Used to revert the "copied" visual feedback after ~2 seconds.
+ */
+function scheduleFeedbackReset(
+	onReset: () => void,
+	delay: number,
+	timer: { setTimeout: (fn: () => void, ms: number) => ReturnType<typeof setTimeout> }
+): ReturnType<typeof setTimeout> {
+	return timer.setTimeout(onReset, delay);
+}
+
+/**
+ * Determines the display label for the code block header.
+ * If a label is provided it is used as-is; otherwise falls back to the language name
+ * (capitalised), or an empty string when neither is provided.
+ */
+function resolveHeaderLabel(label?: string, language?: string): string {
+	if (label !== undefined) return label;
+	if (language) return language.charAt(0).toUpperCase() + language.slice(1);
+	return '';
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('copyCode', () => {
+	it('calls clipboard.writeText with the provided code', async () => {
+		const writeText = vi.fn().mockResolvedValue(undefined);
+		await copyCode('npm install coati', { writeText });
+		expect(writeText).toHaveBeenCalledTimes(1);
+		expect(writeText).toHaveBeenCalledWith('npm install coati');
+	});
+
+	it('calls clipboard.writeText with an empty string when code is empty', async () => {
+		const writeText = vi.fn().mockResolvedValue(undefined);
+		await copyCode('', { writeText });
+		expect(writeText).toHaveBeenCalledWith('');
+	});
+
+	it('preserves multi-line code verbatim', async () => {
+		const multiline = 'line one\nline two\nline three';
+		const writeText = vi.fn().mockResolvedValue(undefined);
+		await copyCode(multiline, { writeText });
+		expect(writeText).toHaveBeenCalledWith(multiline);
+	});
+
+	it('does not call writeText more than once per invocation', async () => {
+		const writeText = vi.fn().mockResolvedValue(undefined);
+		await copyCode('hello', { writeText });
+		expect(writeText).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('scheduleFeedbackReset', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('calls onReset after the specified delay', () => {
+		const onReset = vi.fn();
+		scheduleFeedbackReset(onReset, 2000, { setTimeout: globalThis.setTimeout });
+		expect(onReset).not.toHaveBeenCalled();
+		vi.advanceTimersByTime(2000);
+		expect(onReset).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not call onReset before the delay has elapsed', () => {
+		const onReset = vi.fn();
+		scheduleFeedbackReset(onReset, 2000, { setTimeout: globalThis.setTimeout });
+		vi.advanceTimersByTime(1999);
+		expect(onReset).not.toHaveBeenCalled();
+	});
+
+	it('calls onReset exactly once after delay elapses', () => {
+		const onReset = vi.fn();
+		scheduleFeedbackReset(onReset, 2000, { setTimeout: globalThis.setTimeout });
+		vi.advanceTimersByTime(5000);
+		expect(onReset).toHaveBeenCalledTimes(1);
+	});
+
+	it('returns a handle that can be used to cancel the reset', () => {
+		const onReset = vi.fn();
+		const handle = scheduleFeedbackReset(onReset, 2000, { setTimeout: globalThis.setTimeout });
+		clearTimeout(handle);
+		vi.advanceTimersByTime(2000);
+		expect(onReset).not.toHaveBeenCalled();
+	});
+});
+
+describe('resolveHeaderLabel', () => {
+	it('returns label when explicitly provided', () => {
+		expect(resolveHeaderLabel('Terminal', 'bash')).toBe('Terminal');
+	});
+
+	it('returns label even when it is an empty string', () => {
+		expect(resolveHeaderLabel('', 'bash')).toBe('');
+	});
+
+	it('capitalises and returns language when no label is provided', () => {
+		expect(resolveHeaderLabel(undefined, 'typescript')).toBe('Typescript');
+	});
+
+	it('returns language as-is when already capitalised', () => {
+		expect(resolveHeaderLabel(undefined, 'Bash')).toBe('Bash');
+	});
+
+	it('returns empty string when neither label nor language is provided', () => {
+		expect(resolveHeaderLabel(undefined, undefined)).toBe('');
+	});
+
+	it('returns empty string when both are undefined', () => {
+		expect(resolveHeaderLabel()).toBe('');
+	});
+
+	it('uses label over language when both are provided', () => {
+		expect(resolveHeaderLabel('My File', 'json')).toBe('My File');
+	});
+});

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -12,6 +12,7 @@
 			>
 		</p>
 		<nav class="text-muted-foreground flex gap-3 text-xs lg:gap-4 lg:text-sm">
+			<a href="/guide" class="hover:text-foreground transition-colors">How to use Coati</a>
 			<a
 				href="https://github.com/jimburch/coati"
 				target="_blank"

--- a/src/lib/components/GuideNudge.svelte
+++ b/src/lib/components/GuideNudge.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+	import { browser } from '$app/environment';
+	import { afterNavigate } from '$app/navigation';
+	import { page } from '$app/state';
+	import { X } from '@lucide/svelte';
+	import { buttonVariants } from './ui/button/button.svelte';
+	import { cn } from '$lib/utils.js';
+	import type { LayoutUser } from '$lib/types';
+	import { shouldShowNudge, isGuidePath, GUIDE_DISMISSED_KEY } from '$lib/utils/guide-nudge';
+
+	interface Props {
+		user: LayoutUser | null;
+	}
+
+	const { user }: Props = $props();
+
+	let dismissed = $state(false);
+
+	// Read the localStorage flag on mount (browser only).
+	$effect(() => {
+		if (browser && localStorage.getItem(GUIDE_DISMISSED_KEY)) {
+			dismissed = true;
+		}
+	});
+
+	// Also handle the case where the page is already /guide on initial load.
+	$effect(() => {
+		if (browser && isGuidePath(page.url.pathname)) {
+			dismiss();
+		}
+	});
+
+	// Auto-dismiss when the user navigates to /guide.
+	afterNavigate(({ to }) => {
+		if (to?.url && isGuidePath(to.url.pathname)) {
+			dismiss();
+		}
+	});
+
+	const visible = $derived(shouldShowNudge(user, dismissed));
+
+	function dismiss() {
+		if (browser) {
+			localStorage.setItem(GUIDE_DISMISSED_KEY, '1');
+		}
+		dismissed = true;
+	}
+</script>
+
+{#if visible}
+	<div
+		class="fixed left-4 top-16 z-40 w-72 rounded-lg border bg-background p-4 shadow-md"
+		role="complementary"
+		aria-label="Guide nudge"
+		data-testid="guide-nudge"
+	>
+		<button
+			onclick={dismiss}
+			class="absolute right-2 top-2 flex h-6 w-6 items-center justify-center rounded-sm text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+			aria-label="Dismiss"
+			data-testid="guide-nudge-dismiss"
+		>
+			<X class="size-4" />
+		</button>
+		<p class="pr-6 text-sm font-medium leading-snug text-foreground">
+			New to Coati? Learn how to discover and share AI coding setups.
+		</p>
+		<div class="mt-3">
+			<a
+				href="/guide"
+				class={cn(buttonVariants({ size: 'sm' }), 'w-full justify-center')}
+				data-testid="guide-nudge-cta"
+			>
+				View the Guide
+			</a>
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/guide-nudge.test.ts
+++ b/src/lib/components/guide-nudge.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import type { LayoutUser } from '$lib/types';
+import { GUIDE_DISMISSED_KEY, shouldShowNudge, isGuidePath } from '$lib/utils/guide-nudge';
+
+// ─── Test fixtures ────────────────────────────────────────────────────────────
+
+const betaUser: LayoutUser = {
+	id: 'user-1',
+	username: 'alice',
+	avatarUrl: 'https://example.com/avatar.png',
+	bio: null,
+	isBetaApproved: true,
+	isAdmin: false
+};
+
+const adminUser: LayoutUser = {
+	id: 'user-2',
+	username: 'bob',
+	avatarUrl: 'https://example.com/avatar2.png',
+	bio: null,
+	isBetaApproved: false,
+	isAdmin: true
+};
+
+const nonBetaUser: LayoutUser = {
+	id: 'user-3',
+	username: 'carol',
+	avatarUrl: 'https://example.com/avatar3.png',
+	bio: null,
+	isBetaApproved: false,
+	isAdmin: false
+};
+
+// ─── shouldShowNudge ─────────────────────────────────────────────────────────
+
+describe('shouldShowNudge', () => {
+	it('returns false when user is null (logged out)', () => {
+		expect(shouldShowNudge(null, false)).toBe(false);
+	});
+
+	it('returns false when user is not beta-approved and not admin', () => {
+		expect(shouldShowNudge(nonBetaUser, false)).toBe(false);
+	});
+
+	it('returns true for a beta-approved user who has not dismissed', () => {
+		expect(shouldShowNudge(betaUser, false)).toBe(true);
+	});
+
+	it('returns true for an admin user who has not dismissed', () => {
+		expect(shouldShowNudge(adminUser, false)).toBe(true);
+	});
+
+	it('returns false for a beta-approved user who has dismissed', () => {
+		expect(shouldShowNudge(betaUser, true)).toBe(false);
+	});
+
+	it('returns false for an admin user who has dismissed', () => {
+		expect(shouldShowNudge(adminUser, true)).toBe(false);
+	});
+
+	it('CTA links to /guide — isGuidePath correctly identifies the guide URL', () => {
+		// The CTA href="/guide" matches the auto-dismiss guard
+		expect(isGuidePath('/guide')).toBe(true);
+	});
+});
+
+// ─── isGuidePath ─────────────────────────────────────────────────────────────
+
+describe('isGuidePath', () => {
+	it('returns true for /guide', () => {
+		expect(isGuidePath('/guide')).toBe(true);
+	});
+
+	it('returns false for /', () => {
+		expect(isGuidePath('/')).toBe(false);
+	});
+
+	it('returns false for /guide/section (sub-paths)', () => {
+		expect(isGuidePath('/guide/section')).toBe(false);
+	});
+
+	it('returns false for /explore', () => {
+		expect(isGuidePath('/explore')).toBe(false);
+	});
+
+	it('returns false for empty string', () => {
+		expect(isGuidePath('')).toBe(false);
+	});
+});
+
+// ─── GUIDE_DISMISSED_KEY ─────────────────────────────────────────────────────
+
+describe('GUIDE_DISMISSED_KEY', () => {
+	it('is the expected localStorage key', () => {
+		expect(GUIDE_DISMISSED_KEY).toBe('coati_guide_dismissed');
+	});
+});

--- a/src/lib/utils/guide-nudge.ts
+++ b/src/lib/utils/guide-nudge.ts
@@ -1,0 +1,23 @@
+import type { LayoutUser } from '$lib/types';
+
+/** The localStorage key used to persist nudge dismissal. */
+export const GUIDE_DISMISSED_KEY = 'coati_guide_dismissed';
+
+/**
+ * Returns true when the guide nudge should be visible.
+ * Conditions: user is logged in, is beta-approved (or admin), and has not dismissed.
+ */
+export function shouldShowNudge(user: LayoutUser | null, dismissed: boolean): boolean {
+	if (user === null) return false;
+	if (!user.isBetaApproved && !user.isAdmin) return false;
+	if (dismissed) return false;
+	return true;
+}
+
+/**
+ * Returns true when the current pathname is the guide page,
+ * which triggers auto-dismissal.
+ */
+export function isGuidePath(pathname: string): boolean {
+	return pathname === '/guide';
+}

--- a/src/routes/(public)/guide/+page.svelte
+++ b/src/routes/(public)/guide/+page.svelte
@@ -1,0 +1,256 @@
+<script lang="ts">
+	import CodeBlock from '$lib/components/CodeBlock.svelte';
+	import OgMeta from '$lib/components/OgMeta.svelte';
+
+	const sections = [
+		{ id: 'what-is-coati', title: 'What is Coati?' },
+		{ id: 'discover-setups', title: 'Discover Setups' },
+		{ id: 'install-the-cli', title: 'Install the CLI' },
+		{ id: 'clone-a-setup', title: 'Clone a Setup' },
+		{ id: 'create-your-own-setup', title: 'Create Your Own Setup' },
+		{ id: 'publish-to-coati', title: 'Publish to Coati' },
+		{ id: 'social-features', title: 'Social Features' }
+	];
+</script>
+
+<svelte:head>
+	<title>How to use Coati</title>
+	<meta
+		name="description"
+		content="Learn how to discover, clone, create, and publish AI coding setups with Coati."
+	/>
+</svelte:head>
+
+<OgMeta
+	title="How to use Coati"
+	description="Learn how to discover, clone, create, and publish AI coding setups with Coati."
+	url="/guide"
+	type="website"
+	twitterCard="summary"
+/>
+
+<div class="mx-auto max-w-7xl px-4 py-8 lg:py-12">
+	<!-- Page header -->
+	<div class="mb-10 lg:mb-12">
+		<h1 class="text-3xl font-bold tracking-tight lg:text-4xl">How to use Coati</h1>
+		<p class="mt-2 text-muted-foreground">
+			A guide to discovering, cloning, creating, and sharing AI coding setups.
+		</p>
+	</div>
+
+	<div class="lg:grid lg:grid-cols-[240px_1fr] lg:gap-12">
+		<!-- TOC sidebar (desktop only) -->
+		<aside class="hidden lg:block" aria-label="Table of contents">
+			<nav class="sticky top-20 space-y-1" aria-label="Guide sections">
+				<p class="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+					On this page
+				</p>
+				{#each sections as section (section.id)}
+					<a
+						href="#{section.id}"
+						class="block rounded px-2 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+					>
+						{section.title}
+					</a>
+				{/each}
+			</nav>
+		</aside>
+
+		<!-- Main content -->
+		<div class="min-w-0 space-y-16">
+			<!-- Section 1: What is Coati? -->
+			<section id="what-is-coati" class="scroll-mt-20">
+				<h2 class="mb-4 text-2xl font-bold tracking-tight">What is Coati?</h2>
+				<div class="space-y-4 text-muted-foreground">
+					<p>
+						Coati is a platform for developers to share, discover, and clone AI coding setups —
+						think GitHub, but for your AI workflow. A <strong class="text-foreground">setup</strong>
+						is a packaged collection of config files, scripts, hooks, skills, commands, and documentation
+						that defines how you work with AI coding tools like Claude Code, Cursor, or Windsurf.
+					</p>
+					<p>
+						Whether you've spent hours tuning a perfect <code
+							class="rounded bg-muted px-1 py-0.5 font-mono text-xs text-foreground">CLAUDE.md</code
+						>, built custom slash commands, or wired up a set of hooks — Coati lets you share that
+						work with the community and pick up setups from other developers in seconds.
+					</p>
+				</div>
+			</section>
+
+			<!-- Section 2: Discover Setups -->
+			<section id="discover-setups" class="scroll-mt-20">
+				<h2 class="mb-4 text-2xl font-bold tracking-tight">Discover Setups</h2>
+				<div class="space-y-4 text-muted-foreground">
+					<p>
+						Browse the <a
+							href="/explore"
+							class="text-foreground underline underline-offset-4 hover:text-primary">Explore</a
+						> page to find setups from the community. You can search by keyword, filter by AI agent (Claude
+						Code, Cursor, Windsurf, and more), and sort by trending, most-starred, or newest.
+					</p>
+					<p>
+						Each setup page shows you exactly what's included — the manifest, all config files, and
+						a description from the author. You can star setups you like to save them to your profile
+						and help surface them to others.
+					</p>
+					<p>
+						The <strong class="text-foreground">trending</strong> feed highlights setups gaining the
+						most traction this week. New setups worth watching are easy to find under
+						<strong class="text-foreground">newest</strong>.
+					</p>
+				</div>
+			</section>
+
+			<!-- Section 3: Install the CLI -->
+			<section id="install-the-cli" class="scroll-mt-20">
+				<h2 class="mb-4 text-2xl font-bold tracking-tight">Install the CLI</h2>
+				<div class="space-y-4 text-muted-foreground">
+					<p>
+						The <code class="rounded bg-muted px-1 py-0.5 font-mono text-xs text-foreground"
+							>coati</code
+						> CLI lets you clone setups directly into your project, publish your own, and interact with
+						Coati from the terminal. Install it globally with npm:
+					</p>
+				</div>
+				<div class="mt-4 space-y-4">
+					<CodeBlock code="npm install -g coati" language="bash" label="Install coati globally" />
+					<p class="text-muted-foreground">
+						Once installed, authenticate with your Coati account using GitHub OAuth:
+					</p>
+					<CodeBlock code="coati login" language="bash" label="Authenticate" />
+					<p class="text-muted-foreground">
+						This starts a device flow: you'll be shown a URL and a short code to enter on GitHub.
+						After authenticating, your token is stored at <code
+							class="rounded bg-muted px-1 py-0.5 font-mono text-xs text-foreground"
+							>~/.coati/config.json</code
+						> and used automatically for future commands.
+					</p>
+				</div>
+			</section>
+
+			<!-- Section 4: Clone a Setup -->
+			<section id="clone-a-setup" class="scroll-mt-20">
+				<h2 class="mb-4 text-2xl font-bold tracking-tight">Clone a Setup</h2>
+				<div class="space-y-4 text-muted-foreground">
+					<p>Found a setup you want to use? Clone it into your current project directory:</p>
+				</div>
+				<div class="mt-4 space-y-4">
+					<CodeBlock code="coati clone username/setup-name" language="bash" label="Clone a setup" />
+					<p class="text-muted-foreground">
+						The CLI downloads all files listed in the setup's manifest and writes them to your
+						working directory. If any file already exists, you'll be prompted to confirm before
+						overwriting.
+					</p>
+					<p class="text-muted-foreground">You can also pass a target directory:</p>
+					<CodeBlock
+						code="coati clone username/setup-name ./my-project"
+						language="bash"
+						label="Clone into a specific directory"
+					/>
+				</div>
+			</section>
+
+			<!-- Section 5: Create Your Own Setup -->
+			<section id="create-your-own-setup" class="scroll-mt-20">
+				<h2 class="mb-4 text-2xl font-bold tracking-tight">Create Your Own Setup</h2>
+				<div class="space-y-4 text-muted-foreground">
+					<p>
+						Start from your existing project or an empty directory. The <code
+							class="rounded bg-muted px-1 py-0.5 font-mono text-xs text-foreground"
+							>coati init</code
+						>
+						command scaffolds a
+						<code class="rounded bg-muted px-1 py-0.5 font-mono text-xs text-foreground"
+							>coati.json</code
+						> manifest — the core of every setup:
+					</p>
+				</div>
+				<div class="mt-4 space-y-4">
+					<CodeBlock code="coati init" language="bash" label="Scaffold a new setup" />
+					<p class="text-muted-foreground">
+						The generated manifest describes your setup and lists the files to include:
+					</p>
+					<CodeBlock
+						code={`{
+  "name": "my-setup",
+  "description": "My AI coding workflow for TypeScript projects",
+  "agents": ["claude-code"],
+  "files": [
+    "CLAUDE.md",
+    ".claude/commands/commit.md",
+    ".claude/hooks/pre-tool.sh"
+  ]
+}`}
+						language="json"
+						label="coati.json"
+					/>
+					<p class="text-muted-foreground">
+						Add any files you want to bundle — config files, slash commands, hooks, scripts, or
+						documentation. Then reference them in the <code
+							class="rounded bg-muted px-1 py-0.5 font-mono text-xs text-foreground">files</code
+						> array.
+					</p>
+				</div>
+			</section>
+
+			<!-- Section 6: Publish to Coati -->
+			<section id="publish-to-coati" class="scroll-mt-20">
+				<h2 class="mb-4 text-2xl font-bold tracking-tight">Publish to Coati</h2>
+				<div class="space-y-4 text-muted-foreground">
+					<p>
+						Once your setup is ready and your <code
+							class="rounded bg-muted px-1 py-0.5 font-mono text-xs text-foreground"
+							>coati.json</code
+						> is in place, publish it to the platform:
+					</p>
+				</div>
+				<div class="mt-4 space-y-4">
+					<CodeBlock code="coati publish" language="bash" label="Publish your setup" />
+					<p class="text-muted-foreground">
+						The CLI reads your manifest, uploads all listed files, and creates (or updates) your
+						setup on Coati. Your setup will be immediately visible on your profile and in the
+						Explore page.
+					</p>
+					<p class="text-muted-foreground">
+						To update a published setup, edit your files locally and run <code
+							class="rounded bg-muted px-1 py-0.5 font-mono text-xs text-foreground"
+							>coati publish</code
+						> again — it will overwrite the current version.
+					</p>
+				</div>
+			</section>
+
+			<!-- Section 7: Social Features -->
+			<section id="social-features" class="scroll-mt-20">
+				<h2 class="mb-4 text-2xl font-bold tracking-tight">Social Features</h2>
+				<div class="space-y-4 text-muted-foreground">
+					<p>
+						Coati has lightweight social features to help you find great setups and stay connected
+						with the developers behind them.
+					</p>
+					<ul class="ml-4 list-disc space-y-2">
+						<li>
+							<strong class="text-foreground">Stars</strong> — Star setups to save them to your profile
+							and signal quality to the community. Starred setups appear on your profile for others to
+							find.
+						</li>
+						<li>
+							<strong class="text-foreground">Follows</strong> — Follow developers whose setups you like.
+							Their new setups will appear in your activity feed.
+						</li>
+						<li>
+							<strong class="text-foreground">Activity feed</strong> — See recent activity from people
+							you follow: new setups, stars, and more. Access your feed from the dashboard after signing
+							in.
+						</li>
+					</ul>
+					<p>You can also star and follow directly from the CLI:</p>
+				</div>
+				<div class="mt-4 space-y-4">
+					<CodeBlock code="coati star username/setup-name" language="bash" label="Star a setup" />
+					<CodeBlock code="coati follow username" language="bash" label="Follow a developer" />
+				</div>
+			</section>
+		</div>
+	</div>
+</div>

--- a/src/routes/(public)/guide/guide.test.ts
+++ b/src/routes/(public)/guide/guide.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+
+// Mirror of the sections data defined in +page.svelte
+// Tests ensure all 7 required sections are present with valid anchor IDs and correct order
+
+interface GuideSection {
+	id: string;
+	title: string;
+}
+
+const GUIDE_SECTIONS: GuideSection[] = [
+	{ id: 'what-is-coati', title: 'What is Coati?' },
+	{ id: 'discover-setups', title: 'Discover Setups' },
+	{ id: 'install-the-cli', title: 'Install the CLI' },
+	{ id: 'clone-a-setup', title: 'Clone a Setup' },
+	{ id: 'create-your-own-setup', title: 'Create Your Own Setup' },
+	{ id: 'publish-to-coati', title: 'Publish to Coati' },
+	{ id: 'social-features', title: 'Social Features' }
+];
+
+function isValidAnchorId(id: string): boolean {
+	return /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(id);
+}
+
+describe('GUIDE_SECTIONS', () => {
+	it('has exactly 7 sections', () => {
+		expect(GUIDE_SECTIONS).toHaveLength(7);
+	});
+
+	it('sections are in the required order', () => {
+		const expectedIds = [
+			'what-is-coati',
+			'discover-setups',
+			'install-the-cli',
+			'clone-a-setup',
+			'create-your-own-setup',
+			'publish-to-coati',
+			'social-features'
+		];
+		expect(GUIDE_SECTIONS.map((s) => s.id)).toEqual(expectedIds);
+	});
+
+	it('all sections have non-empty titles', () => {
+		for (const section of GUIDE_SECTIONS) {
+			expect(section.title.trim().length).toBeGreaterThan(0);
+		}
+	});
+
+	it('all section IDs are URL-safe anchor IDs', () => {
+		for (const section of GUIDE_SECTIONS) {
+			expect(isValidAnchorId(section.id)).toBe(true);
+		}
+	});
+
+	it('all section IDs are unique', () => {
+		const ids = GUIDE_SECTIONS.map((s) => s.id);
+		const uniqueIds = new Set(ids);
+		expect(uniqueIds.size).toBe(ids.length);
+	});
+
+	it('section titles match the required content sections', () => {
+		const titles = GUIDE_SECTIONS.map((s) => s.title);
+		expect(titles).toContain('What is Coati?');
+		expect(titles).toContain('Discover Setups');
+		expect(titles).toContain('Install the CLI');
+		expect(titles).toContain('Clone a Setup');
+		expect(titles).toContain('Create Your Own Setup');
+		expect(titles).toContain('Publish to Coati');
+		expect(titles).toContain('Social Features');
+	});
+});
+
+describe('isValidAnchorId', () => {
+	it('accepts lowercase hyphenated strings', () => {
+		expect(isValidAnchorId('what-is-coati')).toBe(true);
+		expect(isValidAnchorId('install-the-cli')).toBe(true);
+		expect(isValidAnchorId('create-your-own-setup')).toBe(true);
+	});
+
+	it('accepts single word IDs', () => {
+		expect(isValidAnchorId('coati')).toBe(true);
+	});
+
+	it('accepts IDs with numbers', () => {
+		expect(isValidAnchorId('section-1')).toBe(true);
+	});
+
+	it('rejects IDs with spaces', () => {
+		expect(isValidAnchorId('what is coati')).toBe(false);
+	});
+
+	it('rejects IDs with uppercase letters', () => {
+		expect(isValidAnchorId('WhatIsCoati')).toBe(false);
+	});
+
+	it('rejects IDs starting with a hyphen', () => {
+		expect(isValidAnchorId('-what-is-coati')).toBe(false);
+	});
+
+	it('rejects IDs ending with a hyphen', () => {
+		expect(isValidAnchorId('what-is-coati-')).toBe(false);
+	});
+
+	it('rejects IDs with consecutive hyphens', () => {
+		expect(isValidAnchorId('what--is-coati')).toBe(false);
+	});
+
+	it('rejects empty string', () => {
+		expect(isValidAnchorId('')).toBe(false);
+	});
+
+	it('rejects IDs with special characters', () => {
+		expect(isValidAnchorId('what-is-coati?')).toBe(false);
+		expect(isValidAnchorId('what_is_coati')).toBe(false);
+	});
+});

--- a/src/routes/(public)/guide/page.svelte.e2e.ts
+++ b/src/routes/(public)/guide/page.svelte.e2e.ts
@@ -1,0 +1,171 @@
+import { expect, test } from '@playwright/test';
+
+const GUIDE_URL = '/guide';
+
+const SECTION_HEADINGS = [
+	'What is Coati?',
+	'Discover Setups',
+	'Install the CLI',
+	'Clone a Setup',
+	'Create Your Own Setup',
+	'Publish to Coati',
+	'Social Features'
+];
+
+const SECTION_IDS = [
+	'what-is-coati',
+	'discover-setups',
+	'install-the-cli',
+	'clone-a-setup',
+	'create-your-own-setup',
+	'publish-to-coati',
+	'social-features'
+];
+
+test('page loads with correct title', async ({ page }) => {
+	await page.goto(GUIDE_URL);
+	await expect(page).toHaveTitle('How to use Coati');
+});
+
+test('page renders the main h1 heading', async ({ page }) => {
+	await page.goto(GUIDE_URL);
+	await expect(page.getByRole('heading', { name: 'How to use Coati', level: 1 })).toBeVisible();
+});
+
+test('all 7 section headings are visible', async ({ page }) => {
+	await page.goto(GUIDE_URL);
+	for (const heading of SECTION_HEADINGS) {
+		await expect(page.getByRole('heading', { name: heading, level: 2 })).toBeVisible();
+	}
+});
+
+test('all section anchor IDs are present in the DOM', async ({ page }) => {
+	await page.goto(GUIDE_URL);
+	for (const id of SECTION_IDS) {
+		const section = page.locator(`#${id}`);
+		await expect(section).toBeAttached();
+	}
+});
+
+test('sections appear in the correct order', async ({ page }) => {
+	await page.goto(GUIDE_URL);
+	const headings = page.getByRole('heading', { level: 2 });
+	const count = await headings.count();
+	expect(count).toBe(SECTION_HEADINGS.length);
+
+	for (let i = 0; i < SECTION_HEADINGS.length; i++) {
+		await expect(headings.nth(i)).toHaveText(SECTION_HEADINGS[i]);
+	}
+});
+
+test('desktop: TOC sidebar is visible', async ({ page, isMobile }) => {
+	test.skip(isMobile, 'desktop-only test');
+	await page.goto(GUIDE_URL);
+	const toc = page.getByRole('navigation', { name: 'Guide sections' });
+	await expect(toc).toBeVisible();
+});
+
+test('mobile: TOC sidebar is hidden', async ({ page, isMobile }) => {
+	test.skip(!isMobile, 'mobile-only test');
+	await page.goto(GUIDE_URL);
+	const tocAside = page.locator('aside[aria-label="Table of contents"]');
+	await expect(tocAside).toBeHidden();
+});
+
+test('desktop: TOC contains links to all 7 sections', async ({ page, isMobile }) => {
+	test.skip(isMobile, 'desktop-only test');
+	await page.goto(GUIDE_URL);
+	const toc = page.getByRole('navigation', { name: 'Guide sections' });
+	for (const section of SECTION_HEADINGS) {
+		await expect(toc.getByRole('link', { name: section })).toBeVisible();
+	}
+});
+
+test('desktop: TOC links have correct href anchors', async ({ page, isMobile }) => {
+	test.skip(isMobile, 'desktop-only test');
+	await page.goto(GUIDE_URL);
+	const toc = page.getByRole('navigation', { name: 'Guide sections' });
+	for (const id of SECTION_IDS) {
+		const link = toc.locator(`a[href="#${id}"]`);
+		await expect(link).toBeAttached();
+	}
+});
+
+test('mobile: page is single-column with no horizontal overflow', async ({ page, isMobile }) => {
+	test.skip(!isMobile, 'mobile-only test');
+	await page.goto(GUIDE_URL);
+	const bodyWidth = await page.evaluate(() => document.body.scrollWidth);
+	const viewportWidth = await page.evaluate(() => window.innerWidth);
+	expect(bodyWidth).toBeLessThanOrEqual(viewportWidth + 1);
+});
+
+test('CodeBlock components are present on the page', async ({ page }) => {
+	await page.goto(GUIDE_URL);
+	// CodeBlock renders a pre > code structure
+	const codeBlocks = page.locator('pre code');
+	const count = await codeBlocks.count();
+	expect(count).toBeGreaterThan(0);
+});
+
+test('copy buttons exist and are accessible', async ({ page }) => {
+	await page.goto(GUIDE_URL);
+	const copyButtons = page.getByRole('button', { name: 'Copy code' });
+	const count = await copyButtons.count();
+	expect(count).toBeGreaterThan(0);
+	// First copy button should be visible
+	await expect(copyButtons.first()).toBeVisible();
+});
+
+test('footer contains "How to use Coati" link pointing to /guide', async ({ page }) => {
+	await page.goto('/');
+	const footerLink = page.locator('footer').getByRole('link', { name: 'How to use Coati' });
+	await expect(footerLink).toBeVisible();
+	await expect(footerLink).toHaveAttribute('href', '/guide');
+});
+
+test('footer "How to use Coati" link navigates to /guide', async ({ page }) => {
+	await page.goto('/');
+	await page.locator('footer').getByRole('link', { name: 'How to use Coati' }).click();
+	await expect(page).toHaveURL(/\/guide$/);
+	await expect(page.getByRole('heading', { name: 'How to use Coati', level: 1 })).toBeVisible();
+});
+
+test('page is accessible without authentication', async ({ page }) => {
+	// No cookies/auth — guide must load for unauthenticated users
+	await page.context().clearCookies();
+	await page.goto(GUIDE_URL);
+	await expect(page.getByRole('heading', { name: 'How to use Coati', level: 1 })).toBeVisible();
+});
+
+test('CLI code examples contain realistic coati commands', async ({ page }) => {
+	await page.goto(GUIDE_URL);
+	const codeBlocks = page.locator('pre code');
+	const allCode = await codeBlocks.allTextContents();
+	const combined = allCode.join('\n');
+	// Check that key CLI commands are present in code blocks
+	expect(combined).toContain('npm install -g coati');
+	expect(combined).toContain('coati login');
+	expect(combined).toContain('coati clone');
+	expect(combined).toContain('coati init');
+	expect(combined).toContain('coati publish');
+});
+
+test('desktop: page heading renders at correct size', async ({ page, isMobile }) => {
+	test.skip(isMobile, 'desktop-only test');
+	await page.goto(GUIDE_URL);
+	await expect(page.getByRole('heading', { name: 'How to use Coati', level: 1 })).toBeVisible();
+});
+
+test('mobile: all section headings are visible without horizontal overflow', async ({
+	page,
+	isMobile
+}) => {
+	test.skip(!isMobile, 'mobile-only test');
+	await page.goto(GUIDE_URL);
+	for (const heading of SECTION_HEADINGS) {
+		await expect(page.getByRole('heading', { name: heading, level: 2 })).toBeVisible();
+	}
+	const bodyWidth = await page.evaluate(() => document.body.scrollWidth);
+	const viewportWidth = await page.evaluate(() => window.innerWidth);
+	expect(bodyWidth).toBeLessThanOrEqual(viewportWidth + 1);
+});

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
 	import Navbar from '$lib/components/Navbar.svelte';
 	import Footer from '$lib/components/Footer.svelte';
 	import FeedbackWidget from '$lib/components/FeedbackWidget.svelte';
+	import GuideNudge from '$lib/components/GuideNudge.svelte';
 	import NavigationProgress from '$lib/components/NavigationProgress.svelte';
 	import { Toaster } from 'svelte-sonner';
 	import '../app.css';
@@ -15,6 +16,7 @@
 		{@render children()}
 	</main>
 	<Footer />
+	<GuideNudge user={data.user} />
 	<FeedbackWidget user={data.user} />
 	<NavigationProgress />
 	<Toaster richColors />


### PR DESCRIPTION
## Summary

- feat(ui): add GuideNudge popover for first-time users (#266)
- feat(ui): add Guide Page with linear journey content and footer link (#265)
- feat(ui): add CodeBlock component with copy-to-clipboard (#264)

Closes #264
Closes #265
Closes #266
Closes #263


## Test plan

See individual issue acceptance criteria for testing details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
