### PR TITLE
feat(ui): new context-rich homepage

### DIFF
--- a/drizzle/0019_activities_setup_id_idx.sql
+++ b/drizzle/0019_activities_setup_id_idx.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "activities_setup_id_created_at_idx" ON "activities" ("setup_id","created_at");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
 			"when": 1744848000000,
 			"tag": "0018_private_setups_teams",
 			"breakpoints": true
+		},
+		{
+			"idx": 20,
+			"version": "7",
+			"when": 1745020800000,
+			"tag": "0019_activities_setup_id_idx",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/lib/components/AgentChips.svelte
+++ b/src/lib/components/AgentChips.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	type Agent = {
+		id: string;
+		slug: string;
+		displayName: string;
+	};
+
+	type Props = {
+		agents: Agent[];
+	};
+
+	const { agents }: Props = $props();
+</script>
+
+{#if agents.length > 0}
+	<div class="rounded-lg border border-border bg-card px-4 py-3">
+		<h2 class="mb-2 text-sm font-semibold text-foreground">Agents</h2>
+		<div class="flex flex-wrap gap-1.5">
+			{#each agents as agent (agent.id)}
+				<a
+					href="/explore?agent={agent.slug}"
+					class="inline-flex items-center rounded-full border border-border bg-secondary px-2.5 py-0.5 text-xs font-medium text-secondary-foreground transition-colors hover:bg-accent"
+				>
+					{agent.displayName}
+				</a>
+			{/each}
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/DiscoveryTabs.svelte
+++ b/src/lib/components/DiscoveryTabs.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+	import SetupCard from './SetupCard.svelte';
+
+	type Setup = {
+		id: string;
+		name: string;
+		slug: string;
+		description: string;
+		display?: string | null;
+		starsCount: number;
+		clonesCount: number;
+		updatedAt: Date;
+		ownerUsername: string;
+		ownerAvatarUrl?: string;
+		agents: { id: string; displayName: string; slug: string }[];
+	};
+
+	type Tab = 'for-you' | 'following' | 'trending';
+
+	type Props = {
+		trendingSetups: Setup[];
+		activeTab: Tab;
+	};
+
+	const { trendingSetups, activeTab }: Props = $props();
+
+	const tabs: { id: Tab; label: string }[] = [
+		{ id: 'for-you', label: 'For You' },
+		{ id: 'following', label: 'Following' },
+		{ id: 'trending', label: 'Trending' }
+	];
+</script>
+
+<section>
+	<nav class="mb-4 flex border-b border-border">
+		{#each tabs as tab (tab.id)}
+			<a
+				href="?tab={tab.id}"
+				class="border-b-2 px-3 py-2 text-sm font-medium transition-colors {activeTab === tab.id
+					? 'border-foreground text-foreground'
+					: 'border-transparent text-muted-foreground hover:border-foreground/40 hover:text-foreground'}"
+				aria-current={activeTab === tab.id ? 'page' : undefined}
+			>
+				{tab.label}
+			</a>
+		{/each}
+	</nav>
+
+	{#if activeTab === 'trending'}
+		{#if trendingSetups.length > 0}
+			<div class="grid grid-cols-2 gap-3">
+				{#each trendingSetups as setup (setup.id)}
+					<SetupCard {setup} username={setup.ownerUsername} showAuthor />
+				{/each}
+			</div>
+		{:else}
+			<div class="rounded-lg border border-dashed border-border py-8 text-center">
+				<p class="text-sm text-muted-foreground">No trending setups yet.</p>
+			</div>
+		{/if}
+		<div class="mt-3 flex justify-end">
+			<a
+				href="/explore?sort=trending"
+				class="text-xs text-muted-foreground transition-colors hover:text-foreground"
+			>
+				View more &rarr;
+			</a>
+		</div>
+	{:else if activeTab === 'following'}
+		<div class="rounded-lg border border-dashed border-border py-8 text-center">
+			<p class="text-sm text-muted-foreground">Setups from people you follow will appear here.</p>
+		</div>
+		<div class="mt-3 flex justify-end">
+			<a
+				href="/explore?filter=following"
+				class="text-xs text-muted-foreground transition-colors hover:text-foreground"
+			>
+				View more &rarr;
+			</a>
+		</div>
+	{:else}
+		<div class="rounded-lg border border-dashed border-border py-8 text-center">
+			<p class="text-sm text-muted-foreground">Personalized recommendations coming soon.</p>
+		</div>
+		<div class="mt-3 flex justify-end">
+			<a
+				href="/explore"
+				class="text-xs text-muted-foreground transition-colors hover:text-foreground"
+			>
+				View more &rarr;
+			</a>
+		</div>
+	{/if}
+</section>

--- a/src/lib/components/DiscoveryTabs.svelte
+++ b/src/lib/components/DiscoveryTabs.svelte
@@ -20,10 +20,11 @@
 	type Props = {
 		trendingSetups: Setup[];
 		forYouSetups: Setup[];
+		followingSetups: Setup[];
 		activeTab: Tab;
 	};
 
-	const { trendingSetups, forYouSetups, activeTab }: Props = $props();
+	const { trendingSetups, forYouSetups, followingSetups, activeTab }: Props = $props();
 
 	const tabs: { id: Tab; label: string }[] = [
 		{ id: 'for-you', label: 'For You' },
@@ -68,12 +69,23 @@
 			</a>
 		</div>
 	{:else if activeTab === 'following'}
-		<div class="rounded-lg border border-dashed border-border py-8 text-center">
-			<p class="text-sm text-muted-foreground">Setups from people you follow will appear here.</p>
-		</div>
+		{#if followingSetups.length > 0}
+			<div class="grid grid-cols-2 gap-3">
+				{#each followingSetups as setup (setup.id)}
+					<SetupCard {setup} username={setup.ownerUsername} showAuthor />
+				{/each}
+			</div>
+		{:else}
+			<div class="rounded-lg border border-dashed border-border py-8 text-center">
+				<p class="text-sm text-muted-foreground">
+					Follow people to see their setups here.
+					<a href="/explore" class="underline hover:text-foreground">Explore setups</a>
+				</p>
+			</div>
+		{/if}
 		<div class="mt-3 flex justify-end">
 			<a
-				href="/explore?filter=following"
+				href="/explore"
 				class="text-xs text-muted-foreground transition-colors hover:text-foreground"
 			>
 				View more &rarr;

--- a/src/lib/components/DiscoveryTabs.svelte
+++ b/src/lib/components/DiscoveryTabs.svelte
@@ -19,10 +19,11 @@
 
 	type Props = {
 		trendingSetups: Setup[];
+		forYouSetups: Setup[];
 		activeTab: Tab;
 	};
 
-	const { trendingSetups, activeTab }: Props = $props();
+	const { trendingSetups, forYouSetups, activeTab }: Props = $props();
 
 	const tabs: { id: Tab; label: string }[] = [
 		{ id: 'for-you', label: 'For You' },
@@ -79,9 +80,19 @@
 			</a>
 		</div>
 	{:else}
-		<div class="rounded-lg border border-dashed border-border py-8 text-center">
-			<p class="text-sm text-muted-foreground">Personalized recommendations coming soon.</p>
-		</div>
+		{#if forYouSetups.length > 0}
+			<div class="grid grid-cols-2 gap-3">
+				{#each forYouSetups as setup (setup.id)}
+					<SetupCard {setup} username={setup.ownerUsername} showAuthor />
+				{/each}
+			</div>
+		{:else}
+			<div class="rounded-lg border border-dashed border-border py-8 text-center">
+				<p class="text-sm text-muted-foreground">
+					No recommendations yet. Star some setups to help us learn your taste!
+				</p>
+			</div>
+		{/if}
 		<div class="mt-3 flex justify-end">
 			<a
 				href="/explore"

--- a/src/lib/components/DiscoveryTabs.test.ts
+++ b/src/lib/components/DiscoveryTabs.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+
+// Pure logic extracted from DiscoveryTabs for unit testing
+
+type Tab = 'for-you' | 'following' | 'trending';
+const VALID_TABS: Tab[] = ['for-you', 'following', 'trending'];
+
+function tabHref(tab: Tab): string {
+	return `?tab=${tab}`;
+}
+
+function resolveActiveTab(raw: string | null): Tab {
+	if (raw !== null && (VALID_TABS as string[]).includes(raw)) {
+		return raw as Tab;
+	}
+	return 'for-you';
+}
+
+function getViewMoreHref(tab: Tab): string {
+	if (tab === 'trending') return '/explore?sort=trending';
+	if (tab === 'following') return '/explore?filter=following';
+	return '/explore';
+}
+
+describe('DiscoveryTabs logic', () => {
+	describe('tabHref', () => {
+		it('generates correct href for for-you tab', () => {
+			expect(tabHref('for-you')).toBe('?tab=for-you');
+		});
+
+		it('generates correct href for following tab', () => {
+			expect(tabHref('following')).toBe('?tab=following');
+		});
+
+		it('generates correct href for trending tab', () => {
+			expect(tabHref('trending')).toBe('?tab=trending');
+		});
+	});
+
+	describe('resolveActiveTab', () => {
+		it('returns for-you when param is null', () => {
+			expect(resolveActiveTab(null)).toBe('for-you');
+		});
+
+		it('returns for-you when param is invalid', () => {
+			expect(resolveActiveTab('invalid')).toBe('for-you');
+		});
+
+		it('returns trending when param is trending', () => {
+			expect(resolveActiveTab('trending')).toBe('trending');
+		});
+
+		it('returns following when param is following', () => {
+			expect(resolveActiveTab('following')).toBe('following');
+		});
+
+		it('returns for-you when param is for-you', () => {
+			expect(resolveActiveTab('for-you')).toBe('for-you');
+		});
+	});
+
+	describe('getViewMoreHref', () => {
+		it('links trending tab to /explore?sort=trending', () => {
+			expect(getViewMoreHref('trending')).toBe('/explore?sort=trending');
+		});
+
+		it('links following tab to /explore?filter=following', () => {
+			expect(getViewMoreHref('following')).toBe('/explore?filter=following');
+		});
+
+		it('links for-you tab to /explore', () => {
+			expect(getViewMoreHref('for-you')).toBe('/explore');
+		});
+	});
+
+	describe('tab order', () => {
+		it('tabs are ordered: For You, Following, Trending', () => {
+			const tabs = [
+				{ id: 'for-you', label: 'For You' },
+				{ id: 'following', label: 'Following' },
+				{ id: 'trending', label: 'Trending' }
+			];
+			expect(tabs[0].id).toBe('for-you');
+			expect(tabs[1].id).toBe('following');
+			expect(tabs[2].id).toBe('trending');
+		});
+	});
+});

--- a/src/lib/components/ProfileCard.svelte
+++ b/src/lib/components/ProfileCard.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import { Avatar, AvatarImage, AvatarFallback } from '$lib/components/ui/avatar';
+
+	type Props = {
+		username: string;
+		avatarUrl: string;
+		name: string | null;
+	};
+
+	const { username, avatarUrl, name }: Props = $props();
+
+	const displayName = $derived(name ?? username);
+	const initials = $derived(displayName[0]?.toUpperCase() ?? '?');
+</script>
+
+<a
+	href="/{username}"
+	class="flex items-center gap-3 rounded-lg border border-border bg-card p-4 transition-colors hover:bg-accent/50"
+>
+	<Avatar class="size-12 shrink-0 text-base">
+		<AvatarImage src={avatarUrl} alt={displayName} />
+		<AvatarFallback>{initials}</AvatarFallback>
+	</Avatar>
+	<div class="min-w-0">
+		<p class="truncate font-semibold text-foreground">{displayName}</p>
+		<p class="truncate text-sm text-muted-foreground">@{username}</p>
+	</div>
+</a>

--- a/src/lib/components/QuickActions.svelte
+++ b/src/lib/components/QuickActions.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+	import { buttonVariants } from '$lib/components/ui/button/button.svelte';
+
+	const CLI_SNIPPET = 'npx @coati/sh@latest';
+	let copied = $state(false);
+
+	function copySnippet() {
+		navigator.clipboard.writeText(CLI_SNIPPET);
+		copied = true;
+		setTimeout(() => (copied = false), 2000);
+	}
+</script>
+
+<div class="rounded-lg border border-border bg-card px-4 py-3">
+	<h2 class="mb-3 text-sm font-semibold text-foreground">Quick Actions</h2>
+	<div class="flex flex-col gap-2">
+		<a href="/new" class={buttonVariants({ variant: 'default', size: 'sm' })}>New setup</a>
+
+		<div class="flex items-center gap-1 rounded-md border border-border bg-muted p-2">
+			<code class="flex-1 truncate text-xs">{CLI_SNIPPET}</code>
+			<button
+				onclick={copySnippet}
+				class="shrink-0 rounded p-1 hover:bg-accent"
+				aria-label="Copy install command"
+			>
+				{#if copied}
+					<svg class="size-4 text-green-500" viewBox="0 0 16 16" fill="currentColor">
+						<path
+							d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.75.75 0 0 1 1.06-1.06L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z"
+						/>
+					</svg>
+				{:else}
+					<svg class="size-4 text-muted-foreground" viewBox="0 0 16 16" fill="currentColor">
+						<path
+							d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"
+						/>
+						<path
+							d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"
+						/>
+					</svg>
+				{/if}
+			</button>
+		</div>
+
+		<a href="/guide" class="text-xs text-muted-foreground transition-colors hover:text-foreground">
+			Learn more &rarr;
+		</a>
+	</div>
+</div>

--- a/src/lib/components/SetupCard.svelte
+++ b/src/lib/components/SetupCard.svelte
@@ -8,12 +8,13 @@
 		setup: SetupCardProps;
 		username: string;
 		showAuthor?: boolean;
-		variant?: 'default' | 'featured';
+		variant?: 'default' | 'featured' | 'compact';
 	};
 
 	const { setup, username, showAuthor = false, variant = 'default' }: Props = $props();
 
 	const featured = $derived(variant === 'featured');
+	const compact = $derived(variant === 'compact');
 
 	const isTeamSetup = $derived(!!setup.teamSlug);
 	const href = $derived(
@@ -25,99 +26,123 @@
 	const overflowCount = $derived(Math.max(0, (setup.agents?.length ?? 0) - MAX_AGENTS));
 </script>
 
-<a
-	{href}
-	class={featured
-		? 'flex h-full flex-col rounded-lg border border-primary/50 bg-card p-5 transition-colors hover:border-foreground/20 hover:bg-accent/50 lg:p-6'
-		: 'flex h-full flex-col rounded-lg border border-border bg-card p-3 transition-colors hover:border-foreground/20 hover:bg-accent/50 lg:p-4'}
->
-	<div class="flex items-center gap-1.5">
-		<h3
-			class={featured
-				? 'truncate text-base font-semibold text-foreground lg:text-lg'
-				: 'truncate text-sm font-semibold text-foreground lg:text-base'}
-		>
-			{setup.display ?? setup.name}
-		</h3>
-		{#if setup.visibility === 'private'}
-			<span
-				class="shrink-0 inline-flex items-center rounded-full border border-border bg-secondary px-2 py-0.5 text-xs font-medium text-secondary-foreground"
-				data-testid="private-badge"
+{#if compact}
+	<a
+		{href}
+		class="flex items-center gap-3 rounded-lg border border-border bg-card px-3 py-2.5 transition-colors hover:border-foreground/20 hover:bg-accent/50"
+	>
+		<div class="min-w-0 flex-1">
+			<span class="block truncate text-sm font-semibold text-foreground"
+				>{setup.display ?? setup.name}</span
 			>
-				Private
-			</span>
-		{/if}
-	</div>
-
-	{#if setup.description}
-		<p
-			class={featured
-				? 'mt-1 text-sm text-muted-foreground'
-				: 'mt-1 line-clamp-2 text-sm text-muted-foreground'}
-		>
-			{setup.description}
-		</p>
-	{/if}
-
-	<div class="mt-2 flex h-6 flex-nowrap items-center gap-1.5 overflow-hidden">
-		{#each visibleAgents as agent (agent.id)}
-			<span
-				class="inline-flex shrink-0 items-center gap-1 rounded-full bg-secondary px-2 py-0.5 text-xs text-secondary-foreground"
-			>
-				<AgentIcon slug={agent.slug} size={16} />
-				{agent.displayName}
-			</span>
-		{/each}
-		{#if overflowCount > 0}
-			<span class="shrink-0 text-xs text-muted-foreground">+{overflowCount}</span>
-		{/if}
-	</div>
-
-	<div class="mt-auto flex items-center gap-3 pt-3 text-xs text-muted-foreground">
-		<span class="inline-flex items-center gap-1">
-			<svg class="size-3.5" viewBox="0 0 16 16" fill="currentColor">
+			{#if setup.description}
+				<span class="block truncate text-xs text-muted-foreground">{setup.description}</span>
+			{/if}
+		</div>
+		<span class="shrink-0 inline-flex items-center gap-1 text-xs text-muted-foreground">
+			<svg class="size-3" viewBox="0 0 16 16" fill="currentColor">
 				<path
 					d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25z"
 				/>
 			</svg>
 			{setup.starsCount}
 		</span>
+	</a>
+{:else}
+	<a
+		{href}
+		class={featured
+			? 'flex h-full flex-col rounded-lg border border-primary/50 bg-card p-5 transition-colors hover:border-foreground/20 hover:bg-accent/50 lg:p-6'
+			: 'flex h-full flex-col rounded-lg border border-border bg-card p-3 transition-colors hover:border-foreground/20 hover:bg-accent/50 lg:p-4'}
+	>
+		<div class="flex items-center gap-1.5">
+			<h3
+				class={featured
+					? 'truncate text-base font-semibold text-foreground lg:text-lg'
+					: 'truncate text-sm font-semibold text-foreground lg:text-base'}
+			>
+				{setup.display ?? setup.name}
+			</h3>
+			{#if setup.visibility === 'private'}
+				<span
+					class="shrink-0 inline-flex items-center rounded-full border border-border bg-secondary px-2 py-0.5 text-xs font-medium text-secondary-foreground"
+					data-testid="private-badge"
+				>
+					Private
+				</span>
+			{/if}
+		</div>
 
-		{#if featured}
+		{#if setup.description}
+			<p
+				class={featured
+					? 'mt-1 text-sm text-muted-foreground'
+					: 'mt-1 line-clamp-2 text-sm text-muted-foreground'}
+			>
+				{setup.description}
+			</p>
+		{/if}
+
+		<div class="mt-2 flex h-6 flex-nowrap items-center gap-1.5 overflow-hidden">
+			{#each visibleAgents as agent (agent.id)}
+				<span
+					class="inline-flex shrink-0 items-center gap-1 rounded-full bg-secondary px-2 py-0.5 text-xs text-secondary-foreground"
+				>
+					<AgentIcon slug={agent.slug} size={16} />
+					{agent.displayName}
+				</span>
+			{/each}
+			{#if overflowCount > 0}
+				<span class="shrink-0 text-xs text-muted-foreground">+{overflowCount}</span>
+			{/if}
+		</div>
+
+		<div class="mt-auto flex items-center gap-3 pt-3 text-xs text-muted-foreground">
 			<span class="inline-flex items-center gap-1">
 				<svg class="size-3.5" viewBox="0 0 16 16" fill="currentColor">
 					<path
-						d="M5 3.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0zm0 2.122a2.25 2.25 0 1 0-1.5 0v.878A2.25 2.25 0 0 0 5.75 8.5h4.5a.75.75 0 0 1 0 1.5h-4.5A2.25 2.25 0 0 0 3.5 12.25v.878a2.25 2.25 0 1 0 1.5 0v-.878a.75.75 0 0 1 .75-.75h4.5a2.25 2.25 0 0 0 2.25-2.25V5.372a2.25 2.25 0 1 0-1.5 0V8.5a.75.75 0 0 1-.75.75h-4.5A2.25 2.25 0 0 0 5 6.128V5.372zm6.75-1.122a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0zm0 9.5a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0z"
+						d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25z"
 					/>
 				</svg>
-				{setup.clonesCount}
+				{setup.starsCount}
 			</span>
-		{/if}
 
-		{#if showAuthor}
-			{#if isTeamSetup}
-				<span class="ml-auto inline-flex items-center gap-1.5">
-					<Avatar class="size-4 text-[8px]">
-						{#if setup.teamAvatarUrl}
-							<AvatarImage src={setup.teamAvatarUrl} alt={setup.teamName ?? ''} />
-						{/if}
-						<AvatarFallback>{(setup.teamName ?? 'T')[0].toUpperCase()}</AvatarFallback>
-					</Avatar>
-					{setup.teamName}
-				</span>
-			{:else}
-				<span class="ml-auto inline-flex items-center gap-1.5">
-					<Avatar class="size-4 text-[8px]">
-						{#if setup.ownerAvatarUrl}
-							<AvatarImage src={setup.ownerAvatarUrl} alt={username} />
-						{/if}
-						<AvatarFallback>{username[0].toUpperCase()}</AvatarFallback>
-					</Avatar>
-					{username}
+			{#if featured}
+				<span class="inline-flex items-center gap-1">
+					<svg class="size-3.5" viewBox="0 0 16 16" fill="currentColor">
+						<path
+							d="M5 3.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0zm0 2.122a2.25 2.25 0 1 0-1.5 0v.878A2.25 2.25 0 0 0 5.75 8.5h4.5a.75.75 0 0 1 0 1.5h-4.5A2.25 2.25 0 0 0 3.5 12.25v.878a2.25 2.25 0 1 0 1.5 0v-.878a.75.75 0 0 1 .75-.75h4.5a2.25 2.25 0 0 0 2.25-2.25V5.372a2.25 2.25 0 1 0-1.5 0V8.5a.75.75 0 0 1-.75.75h-4.5A2.25 2.25 0 0 0 5 6.128V5.372zm6.75-1.122a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0zm0 9.5a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0z"
+						/>
+					</svg>
+					{setup.clonesCount}
 				</span>
 			{/if}
-		{:else}
-			<span class="ml-auto">{timeAgo(setup.updatedAt)}</span>
-		{/if}
-	</div>
-</a>
+
+			{#if showAuthor}
+				{#if isTeamSetup}
+					<span class="ml-auto inline-flex items-center gap-1.5">
+						<Avatar class="size-4 text-[8px]">
+							{#if setup.teamAvatarUrl}
+								<AvatarImage src={setup.teamAvatarUrl} alt={setup.teamName ?? ''} />
+							{/if}
+							<AvatarFallback>{(setup.teamName ?? 'T')[0].toUpperCase()}</AvatarFallback>
+						</Avatar>
+						{setup.teamName}
+					</span>
+				{:else}
+					<span class="ml-auto inline-flex items-center gap-1.5">
+						<Avatar class="size-4 text-[8px]">
+							{#if setup.ownerAvatarUrl}
+								<AvatarImage src={setup.ownerAvatarUrl} alt={username} />
+							{/if}
+							<AvatarFallback>{username[0].toUpperCase()}</AvatarFallback>
+						</Avatar>
+						{username}
+					</span>
+				{/if}
+			{:else}
+				<span class="ml-auto">{timeAgo(setup.updatedAt)}</span>
+			{/if}
+		</div>
+	</a>
+{/if}

--- a/src/lib/components/StatsGrid.svelte
+++ b/src/lib/components/StatsGrid.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	type Stats = {
+		setupsCount: number;
+		starsReceived: number;
+		clonesTotal: number;
+		followingCount: number;
+	};
+
+	type Props = { stats: Stats };
+
+	const { stats }: Props = $props();
+
+	const cells = $derived([
+		{ label: 'Setups', value: stats.setupsCount },
+		{ label: 'Stars received', value: stats.starsReceived },
+		{ label: 'Clones', value: stats.clonesTotal },
+		{ label: 'Following', value: stats.followingCount }
+	]);
+</script>
+
+<div class="grid grid-cols-2 gap-2">
+	{#each cells as cell (cell.label)}
+		<div class="rounded-lg border border-border bg-card p-3 text-center">
+			<p class="text-xl font-bold text-foreground">{cell.value}</p>
+			<p class="mt-0.5 text-xs text-muted-foreground">{cell.label}</p>
+		</div>
+	{/each}
+</div>

--- a/src/lib/components/YourActivityPanel.svelte
+++ b/src/lib/components/YourActivityPanel.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import type { SetupActivityEntry } from '$lib/server/queries/activities';
+
+	type Props = {
+		activity: SetupActivityEntry[];
+		username: string;
+	};
+
+	const { activity, username }: Props = $props();
+</script>
+
+{#if activity.length > 0}
+	<section>
+		<div class="mb-3">
+			<h2 class="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+				Your Activity
+			</h2>
+		</div>
+		<div class="flex flex-col gap-1.5">
+			{#each activity as entry (`${entry.setupId}:${entry.actionType}`)}
+				<div class="rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground">
+					{#if entry.actionType === 'starred_setup'}
+						<span class="text-yellow-500">★</span>
+						+{entry.count} new &middot;
+						<a href="/{username}/{entry.setupSlug}" class="font-medium hover:underline"
+							>{entry.setupName}</a
+						>
+						{#if entry.actorUsernames.length > 0}
+							&middot; {entry.actorUsernames.join(
+								', '
+							)}{#if entry.count > entry.actorUsernames.length}, +{entry.count -
+									entry.actorUsernames.length} more{/if}
+						{/if}
+					{:else if entry.actionType === 'cloned_setup'}
+						<span>⬇</span>
+						{entry.count} new clones of
+						<a href="/{username}/{entry.setupSlug}" class="font-medium hover:underline"
+							>{entry.setupName}</a
+						>
+					{/if}
+				</div>
+			{/each}
+		</div>
+	</section>
+{/if}

--- a/src/lib/components/YourSetupsList.svelte
+++ b/src/lib/components/YourSetupsList.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+	import { timeAgo } from '$lib/utils';
+
+	type UserSetup = {
+		id: string;
+		name: string;
+		slug: string;
+		description: string;
+		display: string | null | undefined;
+		visibility: 'public' | 'private';
+		starsCount: number;
+		updatedAt: Date;
+	};
+
+	type Props = {
+		setups: UserSetup[];
+		username: string;
+	};
+
+	const { setups, username }: Props = $props();
+</script>
+
+<div class="rounded-lg border border-border bg-card">
+	<div class="flex items-center justify-between border-b border-border px-4 py-3">
+		<h2 class="text-sm font-semibold text-foreground">Your Setups</h2>
+		<a
+			href="/{username}"
+			class="text-xs text-muted-foreground transition-colors hover:text-foreground"
+		>
+			View all &rarr;
+		</a>
+	</div>
+	<ul class="divide-y divide-border">
+		{#each setups as setup (setup.id)}
+			<li>
+				<a
+					href="/{username}/{setup.slug}"
+					class="flex items-center justify-between gap-2 px-4 py-3 transition-colors hover:bg-accent/50"
+				>
+					<div class="min-w-0">
+						<p class="truncate text-sm font-medium text-foreground">
+							{setup.display ?? setup.name}
+						</p>
+						<p class="truncate text-xs text-muted-foreground">{timeAgo(setup.updatedAt)}</p>
+					</div>
+					<div class="flex shrink-0 items-center gap-2 text-xs text-muted-foreground">
+						{#if setup.visibility === 'private'}
+							<span
+								class="rounded-full border border-border bg-secondary px-1.5 py-0.5 text-[10px] font-medium text-secondary-foreground"
+							>
+								Private
+							</span>
+						{/if}
+						<span class="inline-flex items-center gap-0.5">
+							<svg class="size-3" viewBox="0 0 16 16" fill="currentColor">
+								<path
+									d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25z"
+								/>
+							</svg>
+							{setup.starsCount}
+						</span>
+					</div>
+				</a>
+			</li>
+		{/each}
+	</ul>
+</div>

--- a/src/lib/components/ZeroStateCard.svelte
+++ b/src/lib/components/ZeroStateCard.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import { buttonVariants } from '$lib/components/ui/button/button.svelte';
+</script>
+
+<div
+	class="flex flex-col items-center rounded-lg border border-dashed border-border bg-card px-6 py-10 text-center"
+>
+	<p class="text-sm font-medium text-foreground">No setups yet</p>
+	<p class="mt-1 text-sm text-muted-foreground">Share your first AI coding workflow.</p>
+	<a href="/new" class="{buttonVariants({ variant: 'default', size: 'sm' })} mt-4">
+		Create a setup
+	</a>
+</div>

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -323,7 +323,10 @@ export const activities = pgTable(
 		actionType: actionTypeEnum('action_type').notNull(),
 		createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull()
 	},
-	(table) => [index('activities_user_id_created_at_idx').on(table.userId, table.createdAt)]
+	(table) => [
+		index('activities_user_id_created_at_idx').on(table.userId, table.createdAt),
+		index('activities_setup_id_created_at_idx').on(table.setupId, table.createdAt)
+	]
 );
 
 // ─── Teams ───────────────────────────────────────────────────────────────────

--- a/src/lib/server/queries/activities.ts
+++ b/src/lib/server/queries/activities.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray, lt, ne, sql } from 'drizzle-orm';
+import { and, desc, eq, gte, inArray, lt, ne, sql } from 'drizzle-orm';
 import type { SQL } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 import { db } from '$lib/server/db';
@@ -152,4 +152,66 @@ export async function getProfileFeed(
 	const filter = eq(activities.userId, userId);
 
 	return queryFeed(filter, PROFILE_ACTION_TYPES, cursor, limit);
+}
+
+export type SetupActivityEntry = {
+	setupId: string;
+	setupName: string;
+	setupSlug: string;
+	actionType: 'starred_setup' | 'cloned_setup';
+	count: number;
+	actorUsernames: string[];
+};
+
+export async function getActivityOnUserSetups(
+	userId: string,
+	sinceDays = 7
+): Promise<SetupActivityEntry[]> {
+	const since = new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000);
+
+	const rows = await db
+		.select({
+			setupId: activities.setupId,
+			setupName: setups.name,
+			setupSlug: setups.slug,
+			actionType: activities.actionType,
+			actorUsername: actorUser.username
+		})
+		.from(activities)
+		.innerJoin(setups, eq(activities.setupId, setups.id))
+		.innerJoin(actorUser, eq(activities.userId, actorUser.id))
+		.where(
+			and(
+				eq(setups.userId, userId),
+				ne(activities.userId, userId),
+				inArray(activities.actionType, ['starred_setup', 'cloned_setup']),
+				gte(activities.createdAt, since)
+			)
+		)
+		.orderBy(desc(activities.createdAt))
+		.limit(500);
+
+	const map = new Map<string, SetupActivityEntry>();
+
+	for (const row of rows) {
+		if (!row.setupId) continue;
+		const key = `${row.setupId}:${row.actionType}`;
+		if (!map.has(key)) {
+			map.set(key, {
+				setupId: row.setupId,
+				setupName: row.setupName ?? '',
+				setupSlug: row.setupSlug ?? '',
+				actionType: row.actionType as 'starred_setup' | 'cloned_setup',
+				count: 0,
+				actorUsernames: []
+			});
+		}
+		const entry = map.get(key)!;
+		entry.count++;
+		if (row.actionType === 'starred_setup' && entry.actorUsernames.length < 3) {
+			entry.actorUsernames.push(row.actorUsername);
+		}
+	}
+
+	return [...map.values()];
 }

--- a/src/lib/server/queries/activityOnUserSetups.test.ts
+++ b/src/lib/server/queries/activityOnUserSetups.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const state = vi.hoisted(() => ({ rows: [] as Record<string, unknown>[] }));
+const mockNe = vi.hoisted(() => vi.fn((a: unknown, b: unknown) => ({ _type: 'ne', a, b })));
+const mockGte = vi.hoisted(() => vi.fn((a: unknown, b: unknown) => ({ _type: 'gte', a, b })));
+
+vi.mock('drizzle-orm', () => {
+	function sqlFn(strings: TemplateStringsArray, ...values: unknown[]) {
+		return { _type: 'sql', strings: Array.from(strings), values };
+	}
+	return {
+		and: vi.fn((...args: unknown[]) => ({ _type: 'and', args })),
+		desc: vi.fn((col: unknown) => ({ _type: 'desc', col })),
+		eq: vi.fn((a: unknown, b: unknown) => ({ _type: 'eq', a, b })),
+		gte: mockGte,
+		inArray: vi.fn((col: unknown, arr: unknown) => ({ _type: 'inArray', col, arr })),
+		lt: vi.fn((a: unknown, b: unknown) => ({ _type: 'lt', a, b })),
+		ne: mockNe,
+		sql: sqlFn
+	};
+});
+
+vi.mock('drizzle-orm/pg-core', () => ({
+	alias: vi.fn(() => ({}))
+}));
+
+vi.mock('$lib/server/db/schema', () => ({
+	activities: {
+		id: 'activities.id',
+		actionType: 'activities.actionType',
+		createdAt: 'activities.createdAt',
+		userId: 'activities.userId',
+		setupId: 'activities.setupId',
+		targetUserId: 'activities.targetUserId',
+		commentId: 'activities.commentId',
+		teamId: 'activities.teamId'
+	},
+	comments: { id: 'comments.id', body: 'comments.body' },
+	follows: { followerId: 'follows.followerId', followingId: 'follows.followingId' },
+	setups: {
+		id: 'setups.id',
+		userId: 'setups.userId',
+		name: 'setups.name',
+		slug: 'setups.slug',
+		visibility: 'setups.visibility',
+		teamId: 'setups.teamId'
+	},
+	teams: {
+		id: 'teams.id',
+		name: 'teams.name',
+		slug: 'teams.slug',
+		avatarUrl: 'teams.avatarUrl'
+	},
+	users: { id: 'users.id', username: 'users.username', avatarUrl: 'users.avatarUrl' }
+}));
+
+vi.mock('$lib/server/db', () => {
+	const chain: Record<string, unknown> = {};
+	const chainMethods = ['select', 'from', 'innerJoin', 'leftJoin', 'where', 'orderBy'];
+	for (const m of chainMethods) {
+		chain[m] = vi.fn(() => chain);
+	}
+	chain['limit'] = vi.fn(() => Promise.resolve(state.rows));
+	return { db: chain };
+});
+
+import { getActivityOnUserSetups } from './activities';
+
+function makeRow(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+	return {
+		setupId: 'setup-1',
+		setupName: 'My Setup',
+		setupSlug: 'my-setup',
+		actionType: 'starred_setup',
+		actorUsername: 'alice',
+		...overrides
+	};
+}
+
+describe('getActivityOnUserSetups', () => {
+	beforeEach(() => {
+		state.rows = [];
+		vi.clearAllMocks();
+	});
+
+	it('returns empty array when no activities in window', async () => {
+		state.rows = [];
+		const result = await getActivityOnUserSetups('user-1');
+		expect(result).toEqual([]);
+	});
+
+	it('aggregates starred_setup rows for same setup into single entry', async () => {
+		state.rows = [
+			makeRow({ setupId: 's1', actionType: 'starred_setup', actorUsername: 'alice' }),
+			makeRow({ setupId: 's1', actionType: 'starred_setup', actorUsername: 'bob' })
+		];
+		const result = await getActivityOnUserSetups('user-1');
+		expect(result).toHaveLength(1);
+		expect(result[0].setupId).toBe('s1');
+		expect(result[0].count).toBe(2);
+		expect(result[0].actionType).toBe('starred_setup');
+	});
+
+	it('populates actorUsernames up to 3 for starred_setup', async () => {
+		state.rows = [
+			makeRow({ setupId: 's1', actionType: 'starred_setup', actorUsername: 'alice' }),
+			makeRow({ setupId: 's1', actionType: 'starred_setup', actorUsername: 'bob' }),
+			makeRow({ setupId: 's1', actionType: 'starred_setup', actorUsername: 'carol' }),
+			makeRow({ setupId: 's1', actionType: 'starred_setup', actorUsername: 'dave' }),
+			makeRow({ setupId: 's1', actionType: 'starred_setup', actorUsername: 'eve' })
+		];
+		const result = await getActivityOnUserSetups('user-1');
+		expect(result[0].count).toBe(5);
+		expect(result[0].actorUsernames).toHaveLength(3);
+		expect(result[0].actorUsernames).toEqual(['alice', 'bob', 'carol']);
+	});
+
+	it('returns empty actorUsernames for cloned_setup', async () => {
+		state.rows = [makeRow({ setupId: 's1', actionType: 'cloned_setup', actorUsername: 'alice' })];
+		const result = await getActivityOnUserSetups('user-1');
+		expect(result[0].actionType).toBe('cloned_setup');
+		expect(result[0].actorUsernames).toEqual([]);
+		expect(result[0].count).toBe(1);
+	});
+
+	it('creates separate entries for different action types on same setup', async () => {
+		state.rows = [
+			makeRow({ setupId: 's1', actionType: 'starred_setup', actorUsername: 'alice' }),
+			makeRow({ setupId: 's1', actionType: 'cloned_setup', actorUsername: 'bob' })
+		];
+		const result = await getActivityOnUserSetups('user-1');
+		expect(result).toHaveLength(2);
+		const types = result.map((e) => e.actionType).sort();
+		expect(types).toEqual(['cloned_setup', 'starred_setup']);
+	});
+
+	it('creates separate entries for different setups', async () => {
+		state.rows = [
+			makeRow({
+				setupId: 's1',
+				setupName: 'Setup A',
+				setupSlug: 'setup-a',
+				actionType: 'starred_setup',
+				actorUsername: 'alice'
+			}),
+			makeRow({
+				setupId: 's2',
+				setupName: 'Setup B',
+				setupSlug: 'setup-b',
+				actionType: 'starred_setup',
+				actorUsername: 'bob'
+			})
+		];
+		const result = await getActivityOnUserSetups('user-1');
+		expect(result).toHaveLength(2);
+		const ids = result.map((e) => e.setupId).sort();
+		expect(ids).toEqual(['s1', 's2']);
+	});
+
+	it('skips rows with null setupId', async () => {
+		state.rows = [makeRow({ setupId: null, actionType: 'starred_setup' })];
+		const result = await getActivityOnUserSetups('user-1');
+		expect(result).toEqual([]);
+	});
+
+	it('passes userId to ne filter to exclude self-actions', async () => {
+		state.rows = [];
+		await getActivityOnUserSetups('user-abc');
+		expect(mockNe).toHaveBeenCalledWith('activities.userId', 'user-abc');
+	});
+
+	it('passes a date approximately sinceDays ago to gte for window filter', async () => {
+		state.rows = [];
+		const before = Date.now();
+		await getActivityOnUserSetups('user-1', 7);
+		const after = Date.now();
+
+		expect(mockGte).toHaveBeenCalledOnce();
+		const [, gteDate] = mockGte.mock.calls[0] as [unknown, Date];
+		const gteDateMs = gteDate.getTime();
+		const expectedMs = before - 7 * 24 * 60 * 60 * 1000;
+
+		expect(gteDateMs).toBeGreaterThanOrEqual(expectedMs - 100);
+		expect(gteDateMs).toBeLessThanOrEqual(after);
+	});
+
+	it('uses sinceDays parameter to compute window boundary', async () => {
+		state.rows = [];
+		const before = Date.now();
+		await getActivityOnUserSetups('user-1', 14);
+
+		const [, gteDate] = mockGte.mock.calls[0] as [unknown, Date];
+		const gteDateMs = gteDate.getTime();
+		const expectedMs = before - 14 * 24 * 60 * 60 * 1000;
+
+		expect(gteDateMs).toBeGreaterThanOrEqual(expectedMs - 100);
+		expect(gteDateMs).toBeLessThanOrEqual(before - 13 * 24 * 60 * 60 * 1000);
+	});
+
+	it('returns correct setupName and setupSlug from row', async () => {
+		state.rows = [
+			makeRow({
+				setupId: 's1',
+				setupName: 'My Awesome Setup',
+				setupSlug: 'my-awesome-setup',
+				actionType: 'starred_setup',
+				actorUsername: 'alice'
+			})
+		];
+		const result = await getActivityOnUserSetups('user-1');
+		expect(result[0].setupName).toBe('My Awesome Setup');
+		expect(result[0].setupSlug).toBe('my-awesome-setup');
+	});
+});

--- a/src/lib/server/queries/followingSetups.test.ts
+++ b/src/lib/server/queries/followingSetups.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockWhere = vi.hoisted(() => vi.fn());
+const mockExecute = vi.hoisted(() => vi.fn());
+const capturedSql = vi.hoisted(() => ({ queries: [] as string[] }));
+
+vi.mock('drizzle-orm', () => {
+	function sqlFn(strings: TemplateStringsArray, ...values: unknown[]) {
+		capturedSql.queries.push(strings.join('__'));
+		return { _type: 'sql', strings: Array.from(strings), values };
+	}
+	sqlFn.join = vi.fn((parts: unknown[], sep: unknown) => ({ _type: 'sql-join', parts, sep }));
+	return {
+		sql: sqlFn,
+		eq: vi.fn((a: unknown, b: unknown) => ({ _type: 'eq', a, b })),
+		and: vi.fn((...args: unknown[]) => ({ _type: 'and', args })),
+		desc: vi.fn((col: unknown) => ({ _type: 'desc', col })),
+		inArray: vi.fn((col: unknown, vals: unknown) => ({ _type: 'inArray', col, vals })),
+		isNotNull: vi.fn(() => ({}))
+	};
+});
+
+vi.mock('$lib/server/db/schema', () => ({
+	setups: {
+		id: 'setups.id',
+		userId: 'setups.userId',
+		name: 'setups.name',
+		slug: 'setups.slug',
+		description: 'setups.description',
+		display: 'setups.display',
+		visibility: 'setups.visibility',
+		starsCount: 'setups.starsCount',
+		clonesCount: 'setups.clonesCount',
+		commentsCount: 'setups.commentsCount',
+		createdAt: 'setups.createdAt',
+		updatedAt: 'setups.updatedAt',
+		searchVector: 'setups.searchVector',
+		featuredAt: 'setups.featuredAt',
+		teamId: 'setups.teamId'
+	},
+	users: {
+		id: 'users.id',
+		username: 'users.username',
+		avatarUrl: 'users.avatarUrl'
+	},
+	setupAgents: { setupId: 'setupAgents.setupId', agentId: 'setupAgents.agentId' },
+	agents: { id: 'agents.id', displayName: 'agents.displayName', slug: 'agents.slug' },
+	setupTags: { setupId: 'setupTags.setupId', tagId: 'setupTags.tagId' },
+	tags: { id: 'tags.id', name: 'tags.name' },
+	stars: {
+		id: 'stars.id',
+		userId: 'stars.userId',
+		setupId: 'stars.setupId',
+		createdAt: 'stars.createdAt'
+	},
+	follows: {
+		id: 'follows.id',
+		followerId: 'follows.followerId',
+		followingId: 'follows.followingId',
+		createdAt: 'follows.createdAt'
+	},
+	activities: {
+		userId: 'activities.userId',
+		setupId: 'activities.setupId',
+		actionType: 'activities.actionType'
+	}
+}));
+
+vi.mock('$lib/server/db', () => {
+	const chain: Record<string, unknown> = {};
+	chain['select'] = vi.fn(() => chain);
+	chain['from'] = vi.fn(() => chain);
+	chain['innerJoin'] = vi.fn(() => chain);
+	chain['where'] = mockWhere;
+	chain['execute'] = mockExecute;
+	return { db: chain };
+});
+
+vi.mock('$lib/server/counters', () => ({ counters: {} }));
+vi.mock('$lib/utils/readme', () => ({ generateReadme: vi.fn(() => '# readme') }));
+
+import { getSetupsFromFollowedUsers } from './setups';
+
+function makeSetupRow(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+	return {
+		id: 'setup-1',
+		name: 'My Setup',
+		slug: 'my-setup',
+		description: 'A great setup',
+		display: null,
+		stars_count: 10,
+		clones_count: 3,
+		created_at: new Date('2026-04-01'),
+		updated_at: new Date('2026-04-01'),
+		owner_username: 'alice',
+		owner_avatar_url: 'https://example.com/alice.png',
+		...overrides
+	};
+}
+
+describe('getSetupsFromFollowedUsers', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		capturedSql.queries = [];
+		mockExecute.mockResolvedValue([]);
+		mockWhere.mockReturnValue(Promise.resolve([]));
+	});
+
+	it('returns empty array when followed users have no setups', async () => {
+		mockExecute.mockResolvedValue([]);
+
+		const result = await getSetupsFromFollowedUsers('user-1', 6);
+		expect(result).toEqual([]);
+	});
+
+	it('returns shaped results with correct field mapping', async () => {
+		mockExecute.mockResolvedValue([makeSetupRow()]);
+
+		const result = await getSetupsFromFollowedUsers('user-1', 1);
+		expect(result[0]).toMatchObject({
+			id: 'setup-1',
+			name: 'My Setup',
+			slug: 'my-setup',
+			description: 'A great setup',
+			display: null,
+			starsCount: 10,
+			clonesCount: 3,
+			ownerUsername: 'alice',
+			ownerAvatarUrl: 'https://example.com/alice.png',
+			agents: []
+		});
+		expect(result[0].createdAt).toBeInstanceOf(Date);
+	});
+
+	it('returns only setups from followed users via follows subquery', async () => {
+		mockExecute.mockResolvedValue([makeSetupRow()]);
+
+		await getSetupsFromFollowedUsers('user-1', 6);
+
+		const hasFollowsSubquery = capturedSql.queries.some(
+			(q) => q.includes('follows') && q.includes('follower_id')
+		);
+		expect(hasFollowsSubquery).toBe(true);
+	});
+
+	it('orders results by DESC', async () => {
+		mockExecute.mockResolvedValue([]);
+
+		await getSetupsFromFollowedUsers('user-1', 6);
+
+		const hasDesc = capturedSql.queries.some((q) => q.includes('DESC'));
+		expect(hasDesc).toBe(true);
+	});
+
+	it('respects the limit parameter', async () => {
+		const rows = Array.from({ length: 6 }, (_, i) =>
+			makeSetupRow({ id: `setup-${i + 1}`, slug: `setup-${i + 1}` })
+		);
+		mockExecute.mockResolvedValue(rows);
+
+		const result = await getSetupsFromFollowedUsers('user-1', 6);
+		expect(result).toHaveLength(6);
+	});
+
+	it('only returns public setups', async () => {
+		mockExecute.mockResolvedValue([]);
+
+		await getSetupsFromFollowedUsers('user-1', 6);
+
+		const hasPublicFilter = capturedSql.queries.some((q) => q.includes('public'));
+		expect(hasPublicFilter).toBe(true);
+	});
+
+	it('returns setups in createdAt desc order when multiple setups exist', async () => {
+		const rows = [
+			makeSetupRow({ id: 'setup-newer', created_at: new Date('2026-04-10') }),
+			makeSetupRow({ id: 'setup-older', slug: 'older', created_at: new Date('2026-03-01') })
+		];
+		mockExecute.mockResolvedValue(rows);
+
+		const result = await getSetupsFromFollowedUsers('user-1', 6);
+		expect(result[0].id).toBe('setup-newer');
+		expect(result[1].id).toBe('setup-older');
+	});
+
+	it('maps multiple rows to shaped output', async () => {
+		mockExecute.mockResolvedValue([
+			makeSetupRow({ id: 'a', slug: 'a' }),
+			makeSetupRow({ id: 'b', slug: 'b' })
+		]);
+
+		const result = await getSetupsFromFollowedUsers('user-1', 6);
+		expect(result).toHaveLength(2);
+		expect(result.map((r) => r.id)).toEqual(['a', 'b']);
+	});
+});

--- a/src/lib/server/queries/forYouSetups.test.ts
+++ b/src/lib/server/queries/forYouSetups.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockWhere = vi.hoisted(() => vi.fn());
+const mockExecute = vi.hoisted(() => vi.fn());
+const capturedSql = vi.hoisted(() => ({ queries: [] as string[] }));
+
+vi.mock('drizzle-orm', () => {
+	function sqlFn(strings: TemplateStringsArray, ...values: unknown[]) {
+		capturedSql.queries.push(strings.join('__'));
+		return { _type: 'sql', strings: Array.from(strings), values };
+	}
+	sqlFn.join = vi.fn((parts: unknown[], sep: unknown) => ({ _type: 'sql-join', parts, sep }));
+	return {
+		sql: sqlFn,
+		eq: vi.fn((a: unknown, b: unknown) => ({ _type: 'eq', a, b })),
+		and: vi.fn((...args: unknown[]) => ({ _type: 'and', args })),
+		desc: vi.fn((col: unknown) => ({ _type: 'desc', col })),
+		inArray: vi.fn((col: unknown, vals: unknown) => ({ _type: 'inArray', col, vals })),
+		isNotNull: vi.fn(() => ({}))
+	};
+});
+
+vi.mock('$lib/server/db/schema', () => ({
+	setups: {
+		id: 'setups.id',
+		userId: 'setups.userId',
+		name: 'setups.name',
+		slug: 'setups.slug',
+		description: 'setups.description',
+		display: 'setups.display',
+		visibility: 'setups.visibility',
+		starsCount: 'setups.starsCount',
+		clonesCount: 'setups.clonesCount',
+		commentsCount: 'setups.commentsCount',
+		createdAt: 'setups.createdAt',
+		updatedAt: 'setups.updatedAt',
+		searchVector: 'setups.searchVector',
+		featuredAt: 'setups.featuredAt',
+		teamId: 'setups.teamId'
+	},
+	users: {
+		id: 'users.id',
+		username: 'users.username',
+		avatarUrl: 'users.avatarUrl'
+	},
+	setupAgents: { setupId: 'setupAgents.setupId', agentId: 'setupAgents.agentId' },
+	agents: { id: 'agents.id', displayName: 'agents.displayName', slug: 'agents.slug' },
+	setupTags: { setupId: 'setupTags.setupId', tagId: 'setupTags.tagId' },
+	tags: { id: 'tags.id', name: 'tags.name' },
+	stars: {
+		id: 'stars.id',
+		userId: 'stars.userId',
+		setupId: 'stars.setupId',
+		createdAt: 'stars.createdAt'
+	},
+	activities: {
+		userId: 'activities.userId',
+		setupId: 'activities.setupId',
+		actionType: 'activities.actionType'
+	}
+}));
+
+vi.mock('$lib/server/db', () => {
+	const chain: Record<string, unknown> = {};
+	chain['select'] = vi.fn(() => chain);
+	chain['from'] = vi.fn(() => chain);
+	chain['innerJoin'] = vi.fn(() => chain);
+	chain['where'] = mockWhere;
+	chain['execute'] = mockExecute;
+	return { db: chain };
+});
+
+vi.mock('$lib/server/counters', () => ({ counters: {} }));
+vi.mock('$lib/utils/readme', () => ({ generateReadme: vi.fn(() => '# readme') }));
+
+import { getForYouSetups } from './setups';
+
+function makeSetupRow(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+	return {
+		id: 'setup-1',
+		name: 'My Setup',
+		slug: 'my-setup',
+		description: 'A great setup',
+		display: null,
+		stars_count: 10,
+		clones_count: 3,
+		updated_at: new Date('2026-04-01'),
+		owner_username: 'alice',
+		owner_avatar_url: 'https://example.com/alice.png',
+		...overrides
+	};
+}
+
+describe('getForYouSetups', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		capturedSql.queries = [];
+		mockWhere.mockReturnValue(Promise.resolve([]));
+		mockExecute.mockReturnValue(Promise.resolve([]));
+	});
+
+	it('returns empty array when no trending setups exist and user has no agents', async () => {
+		mockWhere.mockReturnValueOnce(Promise.resolve([])); // agent lookup → no agents
+		mockExecute.mockResolvedValueOnce([]); // trending → empty
+		mockExecute.mockResolvedValueOnce([]); // backfill → empty
+
+		const result = await getForYouSetups('user-1', 6);
+		expect(result).toEqual([]);
+	});
+
+	it('returns shaped results with correct field mapping', async () => {
+		mockWhere.mockReturnValueOnce(Promise.resolve([{ agentId: 'agent-1' }]));
+		mockExecute.mockResolvedValueOnce([makeSetupRow()]);
+
+		const result = await getForYouSetups('user-1', 1);
+		expect(result[0]).toMatchObject({
+			id: 'setup-1',
+			name: 'My Setup',
+			slug: 'my-setup',
+			description: 'A great setup',
+			display: null,
+			starsCount: 10,
+			clonesCount: 3,
+			ownerUsername: 'alice',
+			ownerAvatarUrl: 'https://example.com/alice.png',
+			agents: []
+		});
+		expect(result[0].updatedAt).toBeInstanceOf(Date);
+	});
+
+	describe('agent-filtered path', () => {
+		it('uses agent subquery filter when user has agents', async () => {
+			mockWhere.mockReturnValueOnce(Promise.resolve([{ agentId: 'agent-1' }]));
+			mockExecute.mockResolvedValueOnce([makeSetupRow()]);
+
+			await getForYouSetups('user-1', 6);
+
+			const hasAgentFilter = capturedSql.queries.some((q) => q.includes('setup_agents sa'));
+			expect(hasAgentFilter).toBe(true);
+		});
+
+		it('excludes user own setups via != condition', async () => {
+			mockWhere.mockReturnValueOnce(Promise.resolve([{ agentId: 'agent-1' }]));
+			mockExecute.mockResolvedValueOnce([]);
+			mockExecute.mockResolvedValueOnce([]);
+
+			await getForYouSetups('user-1', 6);
+
+			const hasOwnExclusion = capturedSql.queries.some((q) => q.includes('!='));
+			expect(hasOwnExclusion).toBe(true);
+		});
+
+		it('excludes starred setups via stars NOT IN subquery', async () => {
+			mockWhere.mockReturnValueOnce(Promise.resolve([{ agentId: 'agent-1' }]));
+			mockExecute.mockResolvedValueOnce([]);
+			mockExecute.mockResolvedValueOnce([]);
+
+			await getForYouSetups('user-1', 6);
+
+			const hasStarsExclusion = capturedSql.queries.some(
+				(q) => q.includes('stars') && q.includes('NOT IN')
+			);
+			expect(hasStarsExclusion).toBe(true);
+		});
+
+		it('returns up to limit results from trending mv', async () => {
+			mockWhere.mockReturnValueOnce(Promise.resolve([{ agentId: 'agent-1' }]));
+			const rows = Array.from({ length: 6 }, (_, i) =>
+				makeSetupRow({ id: `setup-${i + 1}`, slug: `setup-${i + 1}` })
+			);
+			mockExecute.mockResolvedValueOnce(rows);
+
+			const result = await getForYouSetups('user-1', 6);
+			expect(result).toHaveLength(6);
+		});
+
+		it('deduplicates agent IDs from multiple user setups', async () => {
+			// Same agentId on two setups → should still work (dedup is internal)
+			mockWhere.mockReturnValueOnce(
+				Promise.resolve([{ agentId: 'agent-1' }, { agentId: 'agent-1' }])
+			);
+			mockExecute.mockResolvedValueOnce([makeSetupRow()]);
+
+			const result = await getForYouSetups('user-1', 1);
+			expect(result).toHaveLength(1);
+		});
+	});
+
+	describe('no-setups fallback', () => {
+		it('returns global trending results when user has no agents', async () => {
+			mockWhere.mockReturnValueOnce(Promise.resolve([])); // no agents
+			mockExecute.mockResolvedValueOnce([makeSetupRow({ id: 'setup-fallback' })]);
+
+			const result = await getForYouSetups('user-1', 6);
+			expect(result[0].id).toBe('setup-fallback');
+		});
+
+		it('does not include setup_agents subquery filter in fallback path', async () => {
+			mockWhere.mockReturnValueOnce(Promise.resolve([])); // no agents
+			mockExecute.mockResolvedValueOnce([]);
+			mockExecute.mockResolvedValueOnce([]);
+
+			await getForYouSetups('user-1', 6);
+
+			const hasAgentFilter = capturedSql.queries.some((q) => q.includes('setup_agents sa'));
+			expect(hasAgentFilter).toBe(false);
+		});
+
+		it('still excludes starred setups in fallback path', async () => {
+			mockWhere.mockReturnValueOnce(Promise.resolve([])); // no agents
+			mockExecute.mockResolvedValueOnce([]);
+			mockExecute.mockResolvedValueOnce([]);
+
+			await getForYouSetups('user-1', 6);
+
+			const hasStarsExclusion = capturedSql.queries.some(
+				(q) => q.includes('stars') && q.includes('NOT IN')
+			);
+			expect(hasStarsExclusion).toBe(true);
+		});
+
+		it('still queries trending_setups_mv in fallback path', async () => {
+			mockWhere.mockReturnValueOnce(Promise.resolve([]));
+			mockExecute.mockResolvedValueOnce([]);
+			mockExecute.mockResolvedValueOnce([]);
+
+			await getForYouSetups('user-1', 6);
+
+			const hasTrendingMv = capturedSql.queries.some((q) => q.includes('trending_setups_mv'));
+			expect(hasTrendingMv).toBe(true);
+		});
+	});
+
+	describe('backfill', () => {
+		it('combines trending and backfill results when trending is insufficient', async () => {
+			mockWhere.mockReturnValueOnce(Promise.resolve([])); // no agents
+			mockExecute
+				.mockResolvedValueOnce([makeSetupRow({ id: 'setup-1' })]) // trending: 1 of 3
+				.mockResolvedValueOnce([makeSetupRow({ id: 'setup-2', slug: 'setup-2' })]); // backfill
+
+			const result = await getForYouSetups('user-1', 3);
+			expect(result).toHaveLength(2);
+			expect(result[0].id).toBe('setup-1');
+			expect(result[1].id).toBe('setup-2');
+		});
+
+		it('does not run backfill when trending fills all slots', async () => {
+			mockWhere.mockReturnValueOnce(Promise.resolve([])); // no agents
+			const rows = Array.from({ length: 3 }, (_, i) =>
+				makeSetupRow({ id: `setup-${i + 1}`, slug: `setup-${i + 1}` })
+			);
+			mockExecute.mockResolvedValueOnce(rows);
+
+			await getForYouSetups('user-1', 3);
+
+			expect(mockExecute).toHaveBeenCalledTimes(1);
+		});
+
+		it('backfill query excludes setups already in trending_setups_mv', async () => {
+			mockWhere.mockReturnValueOnce(Promise.resolve([])); // no agents
+			mockExecute
+				.mockResolvedValueOnce([]) // trending: empty
+				.mockResolvedValueOnce([]); // backfill: empty
+
+			await getForYouSetups('user-1', 3);
+
+			// Second execute call is the backfill
+			const backfillQuery = capturedSql.queries[1];
+			expect(backfillQuery).toContain('NOT IN');
+			expect(backfillQuery).toContain('trending_setups_mv');
+		});
+
+		it('backfill with agent filter also uses agent subquery', async () => {
+			mockWhere.mockReturnValueOnce(Promise.resolve([{ agentId: 'agent-1' }])); // has agents
+			mockExecute
+				.mockResolvedValueOnce([]) // trending agent-filtered: empty
+				.mockResolvedValueOnce([]); // backfill agent-filtered: empty
+
+			await getForYouSetups('user-1', 3);
+
+			// Both queries should contain setup_agents sa
+			const agentFilteredQueries = capturedSql.queries.filter((q) => q.includes('setup_agents sa'));
+			expect(agentFilteredQueries.length).toBeGreaterThanOrEqual(2);
+		});
+	});
+});

--- a/src/lib/server/queries/getUserSetupAgents.test.ts
+++ b/src/lib/server/queries/getUserSetupAgents.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const state = vi.hoisted(() => ({ rows: [] as Record<string, unknown>[] }));
+
+vi.mock('drizzle-orm', () => ({
+	eq: vi.fn((a: unknown, b: unknown) => ({ _type: 'eq', a, b }))
+}));
+
+vi.mock('$lib/server/db/schema', () => ({
+	setups: { id: 'setups.id', userId: 'setups.userId' },
+	setupAgents: { setupId: 'setupAgents.setupId', agentId: 'setupAgents.agentId' },
+	agents: { id: 'agents.id', slug: 'agents.slug', displayName: 'agents.displayName' }
+}));
+
+vi.mock('$lib/server/db', () => {
+	const chain: Record<string, unknown> = {};
+	chain['select'] = vi.fn(() => chain);
+	chain['from'] = vi.fn(() => chain);
+	chain['innerJoin'] = vi.fn(() => chain);
+	chain['where'] = vi.fn(() => Promise.resolve(state.rows));
+	return { db: chain };
+});
+
+import { getUserSetupAgents } from './users';
+
+describe('getUserSetupAgents', () => {
+	beforeEach(() => {
+		state.rows = [];
+		vi.clearAllMocks();
+	});
+
+	it('returns empty array when user has no setups', async () => {
+		state.rows = [];
+		const result = await getUserSetupAgents('user-1');
+		expect(result).toEqual([]);
+	});
+
+	it('returns distinct agents from a single setup', async () => {
+		state.rows = [
+			{ id: 'agent-1', slug: 'claude-code', displayName: 'Claude Code' },
+			{ id: 'agent-2', slug: 'cursor', displayName: 'Cursor' }
+		];
+		const result = await getUserSetupAgents('user-1');
+		expect(result).toHaveLength(2);
+		expect(result[0]).toMatchObject({
+			id: 'agent-1',
+			slug: 'claude-code',
+			displayName: 'Claude Code'
+		});
+		expect(result[1]).toMatchObject({ id: 'agent-2', slug: 'cursor', displayName: 'Cursor' });
+	});
+
+	it('deduplicates overlapping agents across multiple setups', async () => {
+		// Simulate the DB returning duplicate agent rows (same agent on 2 setups)
+		state.rows = [
+			{ id: 'agent-1', slug: 'claude-code', displayName: 'Claude Code' },
+			{ id: 'agent-2', slug: 'cursor', displayName: 'Cursor' },
+			{ id: 'agent-1', slug: 'claude-code', displayName: 'Claude Code' }, // duplicate from setup 2
+			{ id: 'agent-3', slug: 'copilot', displayName: 'GitHub Copilot' }
+		];
+		const result = await getUserSetupAgents('user-1');
+		expect(result).toHaveLength(3);
+		const slugs = result.map((a) => a.slug);
+		expect(slugs).toContain('claude-code');
+		expect(slugs).toContain('cursor');
+		expect(slugs).toContain('copilot');
+	});
+
+	it('returns only agents whose setups belong to the given user', async () => {
+		state.rows = [{ id: 'agent-1', slug: 'claude-code', displayName: 'Claude Code' }];
+		const result = await getUserSetupAgents('user-abc');
+		expect(result).toHaveLength(1);
+		expect(result[0].slug).toBe('claude-code');
+	});
+});

--- a/src/lib/server/queries/setups.ts
+++ b/src/lib/server/queries/setups.ts
@@ -421,6 +421,138 @@ export async function getTrendingSetups(limit: number, viewerId?: string) {
 	}));
 }
 
+export async function getForYouSetups(userId: string, limit: number) {
+	// Step 1: Determine agent IDs used across the user's setups
+	const agentRows = await db
+		.select({ agentId: setupAgents.agentId })
+		.from(setupAgents)
+		.innerJoin(setups, eq(setupAgents.setupId, setups.id))
+		.where(eq(setups.userId, userId));
+
+	const seen = new Set<string>();
+	const agentIds: string[] = [];
+	for (const row of agentRows) {
+		if (!seen.has(row.agentId)) {
+			seen.add(row.agentId);
+			agentIds.push(row.agentId);
+		}
+	}
+
+	const hasAgents = agentIds.length > 0;
+
+	type SetupRow = {
+		id: string;
+		name: string;
+		slug: string;
+		description: string;
+		display: string | null;
+		stars_count: number;
+		clones_count: number;
+		updated_at: Date;
+		owner_username: string;
+		owner_avatar_url: string;
+	};
+
+	let rows: SetupRow[];
+
+	if (hasAgents) {
+		// Step 2a: Trending setups whose agents overlap with the user's agents
+		rows = await db.execute<SetupRow>(
+			sql`SELECT DISTINCT ${setups.id}, ${setups.name}, ${setups.slug}, ${setups.description},
+				${setups.display}, ${setups.starsCount}, ${setups.clonesCount}, ${setups.updatedAt},
+				${users.username} AS owner_username, ${users.avatarUrl} AS owner_avatar_url
+				FROM ${setups}
+				INNER JOIN ${users} ON ${setups.userId} = ${users.id}
+				INNER JOIN trending_setups_mv ON trending_setups_mv.setup_id = ${setups.id}
+				INNER JOIN ${setupAgents} ON ${setupAgents.setupId} = ${setups.id}
+				WHERE ${setupAgents.agentId} IN (
+					SELECT sa.agent_id FROM setup_agents sa
+					INNER JOIN setups s ON sa.setup_id = s.id
+					WHERE s.user_id = ${userId}
+				)
+				AND ${setups.userId} != ${userId}
+				AND ${setups.id} NOT IN (SELECT setup_id FROM stars WHERE user_id = ${userId})
+				AND ${setups.visibility} = 'public'
+				ORDER BY trending_setups_mv.recent_stars_count DESC
+				LIMIT ${limit}`
+		);
+	} else {
+		// Step 2b: Fallback — global trending with same exclusions
+		rows = await db.execute<SetupRow>(
+			sql`SELECT ${setups.id}, ${setups.name}, ${setups.slug}, ${setups.description},
+				${setups.display}, ${setups.starsCount}, ${setups.clonesCount}, ${setups.updatedAt},
+				${users.username} AS owner_username, ${users.avatarUrl} AS owner_avatar_url
+				FROM ${setups}
+				INNER JOIN ${users} ON ${setups.userId} = ${users.id}
+				INNER JOIN trending_setups_mv ON trending_setups_mv.setup_id = ${setups.id}
+				WHERE ${setups.userId} != ${userId}
+				AND ${setups.id} NOT IN (SELECT setup_id FROM stars WHERE user_id = ${userId})
+				AND ${setups.visibility} = 'public'
+				ORDER BY trending_setups_mv.recent_stars_count DESC
+				LIMIT ${limit}`
+		);
+	}
+
+	if (rows.length < limit) {
+		const backfillLimit = limit - rows.length;
+		let backfillRows: SetupRow[];
+
+		if (hasAgents) {
+			backfillRows = await db.execute<SetupRow>(
+				sql`SELECT DISTINCT ${setups.id}, ${setups.name}, ${setups.slug}, ${setups.description},
+					${setups.display}, ${setups.starsCount}, ${setups.clonesCount}, ${setups.updatedAt},
+					${users.username} AS owner_username, ${users.avatarUrl} AS owner_avatar_url
+					FROM ${setups}
+					INNER JOIN ${users} ON ${setups.userId} = ${users.id}
+					INNER JOIN ${setupAgents} ON ${setupAgents.setupId} = ${setups.id}
+					WHERE ${setupAgents.agentId} IN (
+						SELECT sa.agent_id FROM setup_agents sa
+						INNER JOIN setups s ON sa.setup_id = s.id
+						WHERE s.user_id = ${userId}
+					)
+					AND ${setups.id} NOT IN (SELECT setup_id FROM trending_setups_mv)
+					AND ${setups.userId} != ${userId}
+					AND ${setups.id} NOT IN (SELECT setup_id FROM stars WHERE user_id = ${userId})
+					AND ${setups.visibility} = 'public'
+					ORDER BY ${setups.starsCount} DESC
+					LIMIT ${backfillLimit}`
+			);
+		} else {
+			backfillRows = await db.execute<SetupRow>(
+				sql`SELECT ${setups.id}, ${setups.name}, ${setups.slug}, ${setups.description},
+					${setups.display}, ${setups.starsCount}, ${setups.clonesCount}, ${setups.updatedAt},
+					${users.username} AS owner_username, ${users.avatarUrl} AS owner_avatar_url
+					FROM ${setups}
+					INNER JOIN ${users} ON ${setups.userId} = ${users.id}
+					WHERE ${setups.id} NOT IN (SELECT setup_id FROM trending_setups_mv)
+					AND ${setups.userId} != ${userId}
+					AND ${setups.id} NOT IN (SELECT setup_id FROM stars WHERE user_id = ${userId})
+					AND ${setups.visibility} = 'public'
+					ORDER BY ${setups.starsCount} DESC
+					LIMIT ${backfillLimit}`
+			);
+		}
+		rows = [...rows, ...backfillRows];
+	}
+
+	const setupIds = rows.map((r) => r.id);
+	const agentsMap = setupIds.length > 0 ? await getAgentsForSetups(setupIds) : {};
+
+	return rows.map((row) => ({
+		id: row.id,
+		name: row.name,
+		slug: row.slug,
+		description: row.description,
+		display: row.display,
+		starsCount: row.stars_count,
+		clonesCount: row.clones_count,
+		updatedAt: new Date(row.updated_at),
+		ownerUsername: row.owner_username,
+		ownerAvatarUrl: row.owner_avatar_url,
+		agents: agentsMap[row.id] ?? []
+	}));
+}
+
 export async function getRecentSetups(limit = 12, viewerId?: string) {
 	return db
 		.select({

--- a/src/lib/server/queries/setups.ts
+++ b/src/lib/server/queries/setups.ts
@@ -553,6 +553,56 @@ export async function getForYouSetups(userId: string, limit: number) {
 	}));
 }
 
+export async function getSetupsFromFollowedUsers(userId: string, limit: number) {
+	type SetupRow = {
+		id: string;
+		name: string;
+		slug: string;
+		description: string;
+		display: string | null;
+		stars_count: number;
+		clones_count: number;
+		created_at: Date;
+		updated_at: Date;
+		owner_username: string;
+		owner_avatar_url: string;
+	};
+
+	const rows = await db.execute<SetupRow>(
+		sql`SELECT ${setups.id}, ${setups.name}, ${setups.slug}, ${setups.description},
+			${setups.display}, ${setups.starsCount}, ${setups.clonesCount},
+			${setups.createdAt}, ${setups.updatedAt},
+			${users.username} AS owner_username, ${users.avatarUrl} AS owner_avatar_url
+			FROM ${setups}
+			INNER JOIN ${users} ON ${setups.userId} = ${users.id}
+			WHERE ${setups.userId} IN (
+				SELECT follower_id_sub.following_id FROM follows follower_id_sub
+				WHERE follower_id_sub.follower_id = ${userId}
+			)
+			AND ${setups.visibility} = 'public'
+			ORDER BY ${setups.createdAt} DESC
+			LIMIT ${limit}`
+	);
+
+	const setupIds = rows.map((r) => r.id);
+	const agentsMap = setupIds.length > 0 ? await getAgentsForSetups(setupIds) : {};
+
+	return rows.map((row) => ({
+		id: row.id,
+		name: row.name,
+		slug: row.slug,
+		description: row.description,
+		display: row.display,
+		starsCount: row.stars_count,
+		clonesCount: row.clones_count,
+		createdAt: new Date(row.created_at),
+		updatedAt: new Date(row.updated_at),
+		ownerUsername: row.owner_username,
+		ownerAvatarUrl: row.owner_avatar_url,
+		agents: agentsMap[row.id] ?? []
+	}));
+}
+
 export async function getRecentSetups(limit = 12, viewerId?: string) {
 	return db
 		.select({

--- a/src/lib/server/queries/userDashboard.test.ts
+++ b/src/lib/server/queries/userDashboard.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockLimit = vi.hoisted(() => vi.fn());
+
+vi.mock('drizzle-orm', () => ({
+	eq: vi.fn((a: unknown, b: unknown) => ({ _type: 'eq', a, b })),
+	desc: vi.fn((col: unknown) => ({ _type: 'desc', col })),
+	sql: Object.assign(
+		vi.fn((strings: TemplateStringsArray) => ({ _type: 'sql', raw: strings.join('') })),
+		{ join: vi.fn() }
+	)
+}));
+
+vi.mock('$lib/server/db/schema', () => ({
+	users: { id: 'users.id', followingCount: 'users.followingCount' },
+	setups: {
+		id: 'setups.id',
+		userId: 'setups.userId',
+		name: 'setups.name',
+		slug: 'setups.slug',
+		description: 'setups.description',
+		display: 'setups.display',
+		visibility: 'setups.visibility',
+		starsCount: 'setups.starsCount',
+		clonesCount: 'setups.clonesCount',
+		updatedAt: 'setups.updatedAt'
+	},
+	follows: {
+		id: 'follows.id',
+		followerId: 'follows.followerId',
+		followingId: 'follows.followingId',
+		createdAt: 'follows.createdAt'
+	}
+}));
+
+vi.mock('$lib/server/db', () => {
+	const chain: Record<string, unknown> = {};
+	const syncMethods = ['select', 'from', 'where', 'orderBy'];
+	for (const m of syncMethods) {
+		chain[m] = vi.fn(() => chain);
+	}
+	chain['limit'] = mockLimit;
+	return { db: chain };
+});
+
+import { getUserAggregateStats, getUserSetups } from './users';
+
+describe('getUserAggregateStats', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('returns computed stats for a user with setups and follows', async () => {
+		mockLimit
+			.mockReturnValueOnce(Promise.resolve([{ setupsCount: 3, starsReceived: 12, clonesTotal: 7 }]))
+			.mockReturnValueOnce(Promise.resolve([{ followingCount: 5 }]));
+
+		const result = await getUserAggregateStats('user-1');
+
+		expect(result).toEqual({
+			setupsCount: 3,
+			starsReceived: 12,
+			clonesTotal: 7,
+			followingCount: 5
+		});
+	});
+
+	it('returns zeros when user has no setups or follows', async () => {
+		mockLimit
+			.mockReturnValueOnce(Promise.resolve([{ setupsCount: 0, starsReceived: 0, clonesTotal: 0 }]))
+			.mockReturnValueOnce(Promise.resolve([{ followingCount: 0 }]));
+
+		const result = await getUserAggregateStats('user-empty');
+
+		expect(result).toEqual({
+			setupsCount: 0,
+			starsReceived: 0,
+			clonesTotal: 0,
+			followingCount: 0
+		});
+	});
+
+	it('returns zeros when aggregate queries return empty arrays', async () => {
+		mockLimit.mockReturnValueOnce(Promise.resolve([])).mockReturnValueOnce(Promise.resolve([]));
+
+		const result = await getUserAggregateStats('user-new');
+
+		expect(result).toEqual({
+			setupsCount: 0,
+			starsReceived: 0,
+			clonesTotal: 0,
+			followingCount: 0
+		});
+	});
+});
+
+describe('getUserSetups', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('returns empty array when user has no setups', async () => {
+		mockLimit.mockReturnValueOnce(Promise.resolve([]));
+
+		const result = await getUserSetups('user-1', 5);
+
+		expect(result).toEqual([]);
+	});
+
+	it('returns setups ordered by updatedAt desc up to the limit', async () => {
+		const rows = [
+			{
+				id: 'setup-1',
+				name: 'Alpha',
+				slug: 'alpha',
+				description: 'First',
+				display: null,
+				visibility: 'public',
+				starsCount: 2,
+				clonesCount: 1,
+				updatedAt: new Date('2026-03-10')
+			},
+			{
+				id: 'setup-2',
+				name: 'Beta',
+				slug: 'beta',
+				description: 'Second',
+				display: 'Beta Display',
+				visibility: 'private',
+				starsCount: 0,
+				clonesCount: 0,
+				updatedAt: new Date('2026-02-01')
+			}
+		];
+		mockLimit.mockReturnValueOnce(Promise.resolve(rows));
+
+		const result = await getUserSetups('user-1', 5);
+
+		expect(result).toHaveLength(2);
+		expect(result[0]).toMatchObject({ id: 'setup-1', name: 'Alpha', starsCount: 2 });
+		expect(result[1]).toMatchObject({ id: 'setup-2', name: 'Beta', display: 'Beta Display' });
+	});
+
+	it('includes visibility field including private setups', async () => {
+		const rows = [
+			{
+				id: 'setup-3',
+				name: 'Private Setup',
+				slug: 'private-setup',
+				description: 'My private work',
+				display: null,
+				visibility: 'private',
+				starsCount: 0,
+				clonesCount: 0,
+				updatedAt: new Date('2026-04-01')
+			}
+		];
+		mockLimit.mockReturnValueOnce(Promise.resolve(rows));
+
+		const result = await getUserSetups('user-1', 5);
+
+		expect(result[0].visibility).toBe('private');
+	});
+});

--- a/src/lib/server/queries/users.ts
+++ b/src/lib/server/queries/users.ts
@@ -1,6 +1,6 @@
 import { eq, or, ilike, desc, sql } from 'drizzle-orm';
 import { db } from '$lib/server/db';
-import { users, setups, follows } from '$lib/server/db/schema';
+import { users, setups, follows, setupAgents, agents } from '$lib/server/db/schema';
 
 export async function getUserByUsername(username: string) {
 	const result = await db
@@ -127,6 +127,26 @@ export async function getUserAggregateStats(userId: string) {
 		clonesTotal: s?.clonesTotal ?? 0,
 		followingCount: f?.followingCount ?? 0
 	};
+}
+
+export async function getUserSetupAgents(userId: string) {
+	const rows = await db
+		.select({
+			id: agents.id,
+			slug: agents.slug,
+			displayName: agents.displayName
+		})
+		.from(setups)
+		.innerJoin(setupAgents, eq(setupAgents.setupId, setups.id))
+		.innerJoin(agents, eq(setupAgents.agentId, agents.id))
+		.where(eq(setups.userId, userId));
+
+	const seen = new Set<string>();
+	return rows.filter((row) => {
+		if (seen.has(row.id)) return false;
+		seen.add(row.id);
+		return true;
+	});
 }
 
 export async function getUserSetups(userId: string, limit: number) {

--- a/src/lib/server/queries/users.ts
+++ b/src/lib/server/queries/users.ts
@@ -1,6 +1,6 @@
-import { eq, or, ilike } from 'drizzle-orm';
+import { eq, or, ilike, desc, sql } from 'drizzle-orm';
 import { db } from '$lib/server/db';
-import { users } from '$lib/server/db/schema';
+import { users, setups, follows } from '$lib/server/db/schema';
 
 export async function getUserByUsername(username: string) {
 	const result = await db
@@ -99,4 +99,51 @@ export async function updateUserProfile(userId: string, data: UpdateProfileData)
 		.returning();
 
 	return result[0] ?? null;
+}
+
+export async function getUserAggregateStats(userId: string) {
+	const [setupStats, followStats] = await Promise.all([
+		db
+			.select({
+				setupsCount: sql<number>`count(*)::int`,
+				starsReceived: sql<number>`coalesce(sum(${setups.starsCount}), 0)::int`,
+				clonesTotal: sql<number>`coalesce(sum(${setups.clonesCount}), 0)::int`
+			})
+			.from(setups)
+			.where(eq(setups.userId, userId))
+			.limit(1),
+		db
+			.select({ followingCount: sql<number>`count(*)::int` })
+			.from(follows)
+			.where(eq(follows.followerId, userId))
+			.limit(1)
+	]);
+
+	const s = setupStats[0];
+	const f = followStats[0];
+	return {
+		setupsCount: s?.setupsCount ?? 0,
+		starsReceived: s?.starsReceived ?? 0,
+		clonesTotal: s?.clonesTotal ?? 0,
+		followingCount: f?.followingCount ?? 0
+	};
+}
+
+export async function getUserSetups(userId: string, limit: number) {
+	return db
+		.select({
+			id: setups.id,
+			name: setups.name,
+			slug: setups.slug,
+			description: setups.description,
+			display: setups.display,
+			visibility: setups.visibility,
+			starsCount: setups.starsCount,
+			clonesCount: setups.clonesCount,
+			updatedAt: setups.updatedAt
+		})
+		.from(setups)
+		.where(eq(setups.userId, userId))
+		.orderBy(desc(setups.updatedAt))
+		.limit(limit);
 }

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -11,6 +11,7 @@ import {
 	getUserSetups,
 	getUserSetupAgents
 } from '$lib/server/queries/users';
+import { getActivityOnUserSetups, type SetupActivityEntry } from '$lib/server/queries/activities';
 
 type DashboardSetup = {
 	id: string;
@@ -37,14 +38,16 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 			? (rawTab as Tab)
 			: 'for-you';
 
-		const [featured, recent, userStats, userSetups, userAgents, trending] = await Promise.all([
-			getFeaturedSetups(3, viewerId),
-			getRecentSetups(3, viewerId),
-			getUserAggregateStats(viewerId),
-			getUserSetups(viewerId, 5),
-			getUserSetupAgents(viewerId),
-			getTrendingSetups(6, viewerId)
-		]);
+		const [featured, recent, userStats, userSetups, userAgents, trending, yourActivity] =
+			await Promise.all([
+				getFeaturedSetups(3, viewerId),
+				getRecentSetups(3, viewerId),
+				getUserAggregateStats(viewerId),
+				getUserSetups(viewerId, 5),
+				getUserSetupAgents(viewerId),
+				getTrendingSetups(6, viewerId),
+				getActivityOnUserSetups(viewerId)
+			]);
 
 		const dashboardIds = [...featured.map((s) => s.id), ...recent.map((s) => s.id)];
 		const dashboardAgentsMap =
@@ -79,6 +82,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 			user: locals.user,
 			featuredSetups: featured.map(toCard),
 			recentSetups: recent.map(toCard),
+			yourActivity,
 			trendingSetups: trending.map(
 				(s): DashboardSetup => ({
 					id: s.id,
@@ -136,6 +140,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 			clonesCount: number;
 			updatedAt: Date;
 		}[],
-		userAgents: [] as { id: string; slug: string; displayName: string }[]
+		userAgents: [] as { id: string; slug: string; displayName: string }[],
+		yourActivity: [] as SetupActivityEntry[]
 	};
 };

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,7 +1,6 @@
 import type { PageServerLoad } from './$types';
 import {
 	getFeaturedSetups,
-	getTrendingSetups,
 	getRecentSetups,
 	getAgentsForSetups,
 	searchSetups
@@ -25,19 +24,14 @@ type DashboardSetup = {
 export const load: PageServerLoad = async ({ locals }) => {
 	if (locals.user) {
 		const viewerId = locals.user.id;
-		const [featured, trending, recent, userStats, userSetups] = await Promise.all([
-			getFeaturedSetups(5, viewerId),
-			getTrendingSetups(6, viewerId),
-			getRecentSetups(6, viewerId),
+		const [featured, recent, userStats, userSetups] = await Promise.all([
+			getFeaturedSetups(3, viewerId),
+			getRecentSetups(3, viewerId),
 			getUserAggregateStats(viewerId),
 			getUserSetups(viewerId, 5)
 		]);
 
-		const dashboardIds = [
-			...featured.map((s) => s.id),
-			...trending.map((s) => s.id),
-			...recent.map((s) => s.id)
-		];
+		const dashboardIds = [...featured.map((s) => s.id), ...recent.map((s) => s.id)];
 		const dashboardAgentsMap =
 			dashboardIds.length > 0 ? await getAgentsForSetups(dashboardIds) : {};
 
@@ -69,7 +63,6 @@ export const load: PageServerLoad = async ({ locals }) => {
 		return {
 			user: locals.user,
 			featuredSetups: featured.map(toCard),
-			trendingSetups: trending.map(toCard),
 			recentSetups: recent.map(toCard),
 			userStats,
 			userSetups

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -4,6 +4,7 @@ import {
 	getRecentSetups,
 	getAgentsForSetups,
 	getTrendingSetups,
+	getForYouSetups,
 	searchSetups
 } from '$lib/server/queries/setups';
 import {
@@ -38,7 +39,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 			? (rawTab as Tab)
 			: 'for-you';
 
-		const [featured, recent, userStats, userSetups, userAgents, trending, yourActivity] =
+		const [featured, recent, userStats, userSetups, userAgents, trending, yourActivity, forYou] =
 			await Promise.all([
 				getFeaturedSetups(3, viewerId),
 				getRecentSetups(3, viewerId),
@@ -46,7 +47,8 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 				getUserSetups(viewerId, 5),
 				getUserSetupAgents(viewerId),
 				getTrendingSetups(6, viewerId),
-				getActivityOnUserSetups(viewerId)
+				getActivityOnUserSetups(viewerId),
+				getForYouSetups(viewerId, 6)
 			]);
 
 		const dashboardIds = [...featured.map((s) => s.id), ...recent.map((s) => s.id)];
@@ -98,6 +100,21 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 					agents: []
 				})
 			),
+			forYouSetups: forYou.map(
+				(s): DashboardSetup => ({
+					id: s.id,
+					name: s.name,
+					slug: s.slug,
+					description: s.description,
+					display: s.display,
+					starsCount: s.starsCount,
+					clonesCount: s.clonesCount,
+					updatedAt: s.updatedAt,
+					ownerUsername: s.ownerUsername,
+					ownerAvatarUrl: s.ownerAvatarUrl || undefined,
+					agents: s.agents
+				})
+			),
 			activeTab,
 			userStats,
 			userSetups,
@@ -127,6 +144,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 				agents: agentsMap[s.id] ?? []
 			})
 		),
+		forYouSetups: [] as DashboardSetup[],
 		recentSetups: [] as DashboardSetup[],
 		userStats: null,
 		userSetups: [] as {

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -6,6 +6,7 @@ import {
 	getAgentsForSetups,
 	searchSetups
 } from '$lib/server/queries/setups';
+import { getUserAggregateStats, getUserSetups } from '$lib/server/queries/users';
 
 type DashboardSetup = {
 	id: string;
@@ -24,10 +25,12 @@ type DashboardSetup = {
 export const load: PageServerLoad = async ({ locals }) => {
 	if (locals.user) {
 		const viewerId = locals.user.id;
-		const [featured, trending, recent] = await Promise.all([
+		const [featured, trending, recent, userStats, userSetups] = await Promise.all([
 			getFeaturedSetups(5, viewerId),
 			getTrendingSetups(6, viewerId),
-			getRecentSetups(6, viewerId)
+			getRecentSetups(6, viewerId),
+			getUserAggregateStats(viewerId),
+			getUserSetups(viewerId, 5)
 		]);
 
 		const dashboardIds = [
@@ -67,7 +70,9 @@ export const load: PageServerLoad = async ({ locals }) => {
 			user: locals.user,
 			featuredSetups: featured.map(toCard),
 			trendingSetups: trending.map(toCard),
-			recentSetups: recent.map(toCard)
+			recentSetups: recent.map(toCard),
+			userStats,
+			userSetups
 		};
 	}
 
@@ -93,6 +98,18 @@ export const load: PageServerLoad = async ({ locals }) => {
 				agents: agentsMap[s.id] ?? []
 			})
 		),
-		recentSetups: [] as DashboardSetup[]
+		recentSetups: [] as DashboardSetup[],
+		userStats: null,
+		userSetups: [] as {
+			id: string;
+			name: string;
+			slug: string;
+			description: string;
+			display: string | null | undefined;
+			visibility: 'public' | 'private';
+			starsCount: number;
+			clonesCount: number;
+			updatedAt: Date;
+		}[]
 	};
 };

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -3,6 +3,7 @@ import {
 	getFeaturedSetups,
 	getRecentSetups,
 	getAgentsForSetups,
+	getTrendingSetups,
 	searchSetups
 } from '$lib/server/queries/setups';
 import {
@@ -25,15 +26,24 @@ type DashboardSetup = {
 	agents: { id: string; displayName: string; slug: string }[];
 };
 
-export const load: PageServerLoad = async ({ locals }) => {
+const VALID_TABS = ['for-you', 'following', 'trending'] as const;
+type Tab = (typeof VALID_TABS)[number];
+
+export const load: PageServerLoad = async ({ locals, url }) => {
 	if (locals.user) {
 		const viewerId = locals.user.id;
-		const [featured, recent, userStats, userSetups, userAgents] = await Promise.all([
+		const rawTab = url.searchParams.get('tab');
+		const activeTab: Tab = (VALID_TABS as readonly string[]).includes(rawTab ?? '')
+			? (rawTab as Tab)
+			: 'for-you';
+
+		const [featured, recent, userStats, userSetups, userAgents, trending] = await Promise.all([
 			getFeaturedSetups(3, viewerId),
 			getRecentSetups(3, viewerId),
 			getUserAggregateStats(viewerId),
 			getUserSetups(viewerId, 5),
-			getUserSetupAgents(viewerId)
+			getUserSetupAgents(viewerId),
+			getTrendingSetups(6, viewerId)
 		]);
 
 		const dashboardIds = [...featured.map((s) => s.id), ...recent.map((s) => s.id)];
@@ -69,6 +79,22 @@ export const load: PageServerLoad = async ({ locals }) => {
 			user: locals.user,
 			featuredSetups: featured.map(toCard),
 			recentSetups: recent.map(toCard),
+			trendingSetups: trending.map(
+				(s): DashboardSetup => ({
+					id: s.id,
+					name: s.name,
+					slug: s.slug,
+					description: s.description,
+					display: s.display,
+					starsCount: s.starsCount,
+					clonesCount: s.clonesCount,
+					updatedAt: s.updatedAt,
+					ownerUsername: s.ownerUsername,
+					ownerAvatarUrl: s.ownerAvatarUrl ?? undefined,
+					agents: []
+				})
+			),
+			activeTab,
 			userStats,
 			userSetups,
 			userAgents

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -5,6 +5,7 @@ import {
 	getAgentsForSetups,
 	getTrendingSetups,
 	getForYouSetups,
+	getSetupsFromFollowedUsers,
 	searchSetups
 } from '$lib/server/queries/setups';
 import {
@@ -39,17 +40,27 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 			? (rawTab as Tab)
 			: 'for-you';
 
-		const [featured, recent, userStats, userSetups, userAgents, trending, yourActivity, forYou] =
-			await Promise.all([
-				getFeaturedSetups(3, viewerId),
-				getRecentSetups(3, viewerId),
-				getUserAggregateStats(viewerId),
-				getUserSetups(viewerId, 5),
-				getUserSetupAgents(viewerId),
-				getTrendingSetups(6, viewerId),
-				getActivityOnUserSetups(viewerId),
-				getForYouSetups(viewerId, 6)
-			]);
+		const [
+			featured,
+			recent,
+			userStats,
+			userSetups,
+			userAgents,
+			trending,
+			yourActivity,
+			forYou,
+			following
+		] = await Promise.all([
+			getFeaturedSetups(3, viewerId),
+			getRecentSetups(3, viewerId),
+			getUserAggregateStats(viewerId),
+			getUserSetups(viewerId, 5),
+			getUserSetupAgents(viewerId),
+			getTrendingSetups(6, viewerId),
+			getActivityOnUserSetups(viewerId),
+			getForYouSetups(viewerId, 6),
+			getSetupsFromFollowedUsers(viewerId, 6)
+		]);
 
 		const dashboardIds = [...featured.map((s) => s.id), ...recent.map((s) => s.id)];
 		const dashboardAgentsMap =
@@ -115,6 +126,21 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 					agents: s.agents
 				})
 			),
+			followingSetups: following.map(
+				(s): DashboardSetup => ({
+					id: s.id,
+					name: s.name,
+					slug: s.slug,
+					description: s.description,
+					display: s.display,
+					starsCount: s.starsCount,
+					clonesCount: s.clonesCount,
+					updatedAt: s.updatedAt,
+					ownerUsername: s.ownerUsername,
+					ownerAvatarUrl: s.ownerAvatarUrl || undefined,
+					agents: s.agents
+				})
+			),
 			activeTab,
 			userStats,
 			userSetups,
@@ -145,6 +171,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 			})
 		),
 		forYouSetups: [] as DashboardSetup[],
+		followingSetups: [] as DashboardSetup[],
 		recentSetups: [] as DashboardSetup[],
 		userStats: null,
 		userSetups: [] as {

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -5,7 +5,11 @@ import {
 	getAgentsForSetups,
 	searchSetups
 } from '$lib/server/queries/setups';
-import { getUserAggregateStats, getUserSetups } from '$lib/server/queries/users';
+import {
+	getUserAggregateStats,
+	getUserSetups,
+	getUserSetupAgents
+} from '$lib/server/queries/users';
 
 type DashboardSetup = {
 	id: string;
@@ -24,11 +28,12 @@ type DashboardSetup = {
 export const load: PageServerLoad = async ({ locals }) => {
 	if (locals.user) {
 		const viewerId = locals.user.id;
-		const [featured, recent, userStats, userSetups] = await Promise.all([
+		const [featured, recent, userStats, userSetups, userAgents] = await Promise.all([
 			getFeaturedSetups(3, viewerId),
 			getRecentSetups(3, viewerId),
 			getUserAggregateStats(viewerId),
-			getUserSetups(viewerId, 5)
+			getUserSetups(viewerId, 5),
+			getUserSetupAgents(viewerId)
 		]);
 
 		const dashboardIds = [...featured.map((s) => s.id), ...recent.map((s) => s.id)];
@@ -65,7 +70,8 @@ export const load: PageServerLoad = async ({ locals }) => {
 			featuredSetups: featured.map(toCard),
 			recentSetups: recent.map(toCard),
 			userStats,
-			userSetups
+			userSetups,
+			userAgents
 		};
 	}
 
@@ -103,6 +109,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 			starsCount: number;
 			clonesCount: number;
 			updatedAt: Date;
-		}[]
+		}[],
+		userAgents: [] as { id: string; slug: string; displayName: string }[]
 	};
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,6 +6,8 @@
 	import StatsGrid from '$lib/components/StatsGrid.svelte';
 	import YourSetupsList from '$lib/components/YourSetupsList.svelte';
 	import ZeroStateCard from '$lib/components/ZeroStateCard.svelte';
+	import QuickActions from '$lib/components/QuickActions.svelte';
+	import AgentChips from '$lib/components/AgentChips.svelte';
 	import { Upload, Search, Download } from '@lucide/svelte';
 
 	const { data } = $props();
@@ -49,6 +51,8 @@
 					{/if}
 					<YourSetupsList setups={data.userSetups} username={data.user.username} />
 				{/if}
+				<QuickActions />
+				<AgentChips agents={data.userAgents} />
 			</aside>
 
 			<!-- Right column: discovery sections -->

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,6 +9,7 @@
 	import QuickActions from '$lib/components/QuickActions.svelte';
 	import AgentChips from '$lib/components/AgentChips.svelte';
 	import DiscoveryTabs from '$lib/components/DiscoveryTabs.svelte';
+	import YourActivityPanel from '$lib/components/YourActivityPanel.svelte';
 	import { Upload, Search, Download } from '@lucide/svelte';
 
 	const { data } = $props();
@@ -59,6 +60,8 @@
 			<!-- Right column: discovery sections -->
 			<div class="flex flex-col gap-6">
 				<DiscoveryTabs trendingSetups={data.trendingSetups} activeTab={data.activeTab} />
+
+				<YourActivityPanel activity={data.yourActivity} username={data.user.username} />
 
 				{#if data.featuredSetups.length > 0}
 					<!-- Featured Setups -->

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,8 +12,6 @@
 
 	const LBRACE = '{';
 	const RBRACE = '}';
-
-	let showAllTrending = $state(false);
 </script>
 
 <svelte:head>
@@ -54,80 +52,46 @@
 			</aside>
 
 			<!-- Right column: discovery sections -->
-			<div class="flex flex-col gap-0">
+			<div class="flex flex-col gap-6">
 				{#if data.featuredSetups.length > 0}
 					<!-- Featured Setups -->
-					<section class="border-b border-border pb-8 lg:pb-10">
-						<div class="mb-5 flex items-baseline justify-between lg:mb-6">
-							<h2 class="text-lg font-bold tracking-tight lg:text-xl">Featured Setups</h2>
+					<section>
+						<div class="mb-3 flex items-baseline justify-between">
+							<h2 class="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+								Featured
+							</h2>
 						</div>
-						<div class="grid grid-cols-1 gap-4 lg:grid-cols-2 xl:grid-cols-3">
+						<div class="flex flex-col gap-1.5">
 							{#each data.featuredSetups as setup (setup.id)}
-								<SetupCard {setup} username={setup.ownerUsername} showAuthor variant="featured" />
+								<SetupCard {setup} username={setup.ownerUsername} showAuthor variant="compact" />
 							{/each}
 						</div>
 					</section>
 				{/if}
 
-				<!-- Trending -->
-				<section class="border-b border-border py-8 lg:py-10">
-					<div class="mb-5 flex items-baseline justify-between lg:mb-6">
-						<h2 class="text-lg font-bold tracking-tight lg:text-xl">Trending</h2>
-						<a
-							href="/explore?sort=trending"
-							class="text-sm text-muted-foreground transition-colors hover:text-foreground"
-						>
-							View all trending &rarr;
-						</a>
-					</div>
-
-					{#if data.trendingSetups.length > 0}
-						<div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-							{#each data.trendingSetups as setup, i (setup.id)}
-								<div class={i >= 3 && !showAllTrending ? 'hidden lg:block' : ''}>
-									<SetupCard {setup} username={setup.ownerUsername} showAuthor />
-								</div>
-							{/each}
-						</div>
-
-						{#if data.trendingSetups.length > 3}
-							<div class="mt-4 text-center lg:hidden">
-								<button
-									onclick={() => (showAllTrending = !showAllTrending)}
-									class={buttonVariants({ variant: 'outline', size: 'sm' })}
-								>
-									{showAllTrending ? 'Show less' : 'Show more'}
-								</button>
-							</div>
-						{/if}
-					{:else}
-						<div class="rounded-lg border border-dashed border-border py-12 text-center">
-							<p class="text-muted-foreground">No trending setups yet.</p>
-						</div>
-					{/if}
-				</section>
-
 				<!-- Recently Added -->
-				<section class="pt-8 lg:pt-10">
-					<div class="mb-5 flex items-baseline justify-between lg:mb-6">
-						<h2 class="text-lg font-bold tracking-tight lg:text-xl">Recently Added</h2>
+				<section>
+					<div class="mb-3 flex items-baseline justify-between">
+						<h2 class="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+							Recently Added
+						</h2>
 						<a
-							href="/explore?sort=newest"
-							class="text-sm text-muted-foreground transition-colors hover:text-foreground"
+							href="/explore"
+							class="text-xs text-muted-foreground transition-colors hover:text-foreground"
 						>
-							View all recent &rarr;
+							View all &rarr;
 						</a>
 					</div>
 
 					{#if data.recentSetups.length > 0}
-						<div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+						<div class="flex flex-col gap-1.5">
 							{#each data.recentSetups as setup (setup.id)}
-								<SetupCard {setup} username={setup.ownerUsername} showAuthor />
+								<SetupCard {setup} username={setup.ownerUsername} showAuthor variant="compact" />
 							{/each}
 						</div>
 					{:else}
-						<div class="rounded-lg border border-dashed border-border py-12 text-center">
-							<p class="text-muted-foreground">No setups yet. Be the first to share one!</p>
+						<div class="rounded-lg border border-dashed border-border py-8 text-center">
+							<p class="text-sm text-muted-foreground">No setups yet. Be the first to share one!</p>
 						</div>
 					{/if}
 				</section>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,6 +2,10 @@
 	import { buttonVariants } from '$lib/components/ui/button/button.svelte';
 	import SetupCard from '$lib/components/SetupCard.svelte';
 	import OgMeta from '$lib/components/OgMeta.svelte';
+	import ProfileCard from '$lib/components/ProfileCard.svelte';
+	import StatsGrid from '$lib/components/StatsGrid.svelte';
+	import YourSetupsList from '$lib/components/YourSetupsList.svelte';
+	import ZeroStateCard from '$lib/components/ZeroStateCard.svelte';
 	import { Upload, Search, Download } from '@lucide/svelte';
 
 	const { data } = $props();
@@ -29,90 +33,107 @@
 />
 
 {#if data.user}
-	<!-- Authenticated: Discovery Dashboard -->
-
-	{#if data.featuredSetups.length > 0}
-		<!-- Featured Setups -->
-		<section class="border-b border-border">
-			<div class="mx-auto max-w-7xl px-4 py-10 lg:py-16">
-				<div class="mb-6 flex items-baseline justify-between lg:mb-8">
-					<h2 class="text-xl font-bold tracking-tight lg:text-2xl">Featured Setups</h2>
-				</div>
-				<div class="grid grid-cols-1 gap-4 lg:grid-cols-2 xl:grid-cols-3">
-					{#each data.featuredSetups as setup (setup.id)}
-						<SetupCard {setup} username={setup.ownerUsername} showAuthor variant="featured" />
-					{/each}
-				</div>
-			</div>
-		</section>
-	{/if}
-
-	<!-- Trending -->
-	<section class="border-b border-border">
-		<div class="mx-auto max-w-7xl px-4 py-10 lg:py-16">
-			<div class="mb-6 flex items-baseline justify-between lg:mb-8">
-				<h2 class="text-xl font-bold tracking-tight lg:text-2xl">Trending</h2>
-				<a
-					href="/explore?sort=trending"
-					class="text-sm text-muted-foreground transition-colors hover:text-foreground"
-				>
-					View all trending &rarr;
-				</a>
-			</div>
-
-			{#if data.trendingSetups.length > 0}
-				<div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-					{#each data.trendingSetups as setup, i (setup.id)}
-						<div class={i >= 3 && !showAllTrending ? 'hidden lg:block' : ''}>
-							<SetupCard {setup} username={setup.ownerUsername} showAuthor />
-						</div>
-					{/each}
-				</div>
-
-				{#if data.trendingSetups.length > 3}
-					<div class="mt-4 text-center lg:hidden">
-						<button
-							onclick={() => (showAllTrending = !showAllTrending)}
-							class={buttonVariants({ variant: 'outline', size: 'sm' })}
-						>
-							{showAllTrending ? 'Show less' : 'Show more'}
-						</button>
-					</div>
+	<!-- Authenticated: Two-column dashboard -->
+	<div class="mx-auto max-w-7xl px-4 py-6 lg:py-10">
+		<div class="flex flex-col gap-6 lg:grid lg:grid-cols-[280px_1fr]">
+			<!-- Left rail: identity -->
+			<aside class="flex flex-col gap-4">
+				<ProfileCard
+					username={data.user.username}
+					avatarUrl={data.user.avatarUrl}
+					name={data.user.name ?? null}
+				/>
+				{#if data.userSetups.length === 0}
+					<ZeroStateCard />
+				{:else}
+					{#if data.userStats}
+						<StatsGrid stats={data.userStats} />
+					{/if}
+					<YourSetupsList setups={data.userSetups} username={data.user.username} />
 				{/if}
-			{:else}
-				<div class="rounded-lg border border-dashed border-border py-12 text-center">
-					<p class="text-muted-foreground">No trending setups yet.</p>
-				</div>
-			{/if}
-		</div>
-	</section>
+			</aside>
 
-	<!-- Recently Added -->
-	<section>
-		<div class="mx-auto max-w-7xl px-4 py-10 lg:py-16">
-			<div class="mb-6 flex items-baseline justify-between lg:mb-8">
-				<h2 class="text-xl font-bold tracking-tight lg:text-2xl">Recently Added</h2>
-				<a
-					href="/explore?sort=newest"
-					class="text-sm text-muted-foreground transition-colors hover:text-foreground"
-				>
-					View all recent &rarr;
-				</a>
+			<!-- Right column: discovery sections -->
+			<div class="flex flex-col gap-0">
+				{#if data.featuredSetups.length > 0}
+					<!-- Featured Setups -->
+					<section class="border-b border-border pb-8 lg:pb-10">
+						<div class="mb-5 flex items-baseline justify-between lg:mb-6">
+							<h2 class="text-lg font-bold tracking-tight lg:text-xl">Featured Setups</h2>
+						</div>
+						<div class="grid grid-cols-1 gap-4 lg:grid-cols-2 xl:grid-cols-3">
+							{#each data.featuredSetups as setup (setup.id)}
+								<SetupCard {setup} username={setup.ownerUsername} showAuthor variant="featured" />
+							{/each}
+						</div>
+					</section>
+				{/if}
+
+				<!-- Trending -->
+				<section class="border-b border-border py-8 lg:py-10">
+					<div class="mb-5 flex items-baseline justify-between lg:mb-6">
+						<h2 class="text-lg font-bold tracking-tight lg:text-xl">Trending</h2>
+						<a
+							href="/explore?sort=trending"
+							class="text-sm text-muted-foreground transition-colors hover:text-foreground"
+						>
+							View all trending &rarr;
+						</a>
+					</div>
+
+					{#if data.trendingSetups.length > 0}
+						<div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+							{#each data.trendingSetups as setup, i (setup.id)}
+								<div class={i >= 3 && !showAllTrending ? 'hidden lg:block' : ''}>
+									<SetupCard {setup} username={setup.ownerUsername} showAuthor />
+								</div>
+							{/each}
+						</div>
+
+						{#if data.trendingSetups.length > 3}
+							<div class="mt-4 text-center lg:hidden">
+								<button
+									onclick={() => (showAllTrending = !showAllTrending)}
+									class={buttonVariants({ variant: 'outline', size: 'sm' })}
+								>
+									{showAllTrending ? 'Show less' : 'Show more'}
+								</button>
+							</div>
+						{/if}
+					{:else}
+						<div class="rounded-lg border border-dashed border-border py-12 text-center">
+							<p class="text-muted-foreground">No trending setups yet.</p>
+						</div>
+					{/if}
+				</section>
+
+				<!-- Recently Added -->
+				<section class="pt-8 lg:pt-10">
+					<div class="mb-5 flex items-baseline justify-between lg:mb-6">
+						<h2 class="text-lg font-bold tracking-tight lg:text-xl">Recently Added</h2>
+						<a
+							href="/explore?sort=newest"
+							class="text-sm text-muted-foreground transition-colors hover:text-foreground"
+						>
+							View all recent &rarr;
+						</a>
+					</div>
+
+					{#if data.recentSetups.length > 0}
+						<div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+							{#each data.recentSetups as setup (setup.id)}
+								<SetupCard {setup} username={setup.ownerUsername} showAuthor />
+							{/each}
+						</div>
+					{:else}
+						<div class="rounded-lg border border-dashed border-border py-12 text-center">
+							<p class="text-muted-foreground">No setups yet. Be the first to share one!</p>
+						</div>
+					{/if}
+				</section>
 			</div>
-
-			{#if data.recentSetups.length > 0}
-				<div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-					{#each data.recentSetups as setup (setup.id)}
-						<SetupCard {setup} username={setup.ownerUsername} showAuthor />
-					{/each}
-				</div>
-			{:else}
-				<div class="rounded-lg border border-dashed border-border py-12 text-center">
-					<p class="text-muted-foreground">No setups yet. Be the first to share one!</p>
-				</div>
-			{/if}
 		</div>
-	</section>
+	</div>
 {:else}
 	<!-- Unauthenticated: Marketing landing page -->
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -59,7 +59,11 @@
 
 			<!-- Right column: discovery sections -->
 			<div class="flex flex-col gap-6">
-				<DiscoveryTabs trendingSetups={data.trendingSetups} activeTab={data.activeTab} />
+				<DiscoveryTabs
+					trendingSetups={data.trendingSetups}
+					forYouSetups={data.forYouSetups}
+					activeTab={data.activeTab}
+				/>
 
 				<YourActivityPanel activity={data.yourActivity} username={data.user.username} />
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,6 +8,7 @@
 	import ZeroStateCard from '$lib/components/ZeroStateCard.svelte';
 	import QuickActions from '$lib/components/QuickActions.svelte';
 	import AgentChips from '$lib/components/AgentChips.svelte';
+	import DiscoveryTabs from '$lib/components/DiscoveryTabs.svelte';
 	import { Upload, Search, Download } from '@lucide/svelte';
 
 	const { data } = $props();
@@ -57,6 +58,8 @@
 
 			<!-- Right column: discovery sections -->
 			<div class="flex flex-col gap-6">
+				<DiscoveryTabs trendingSetups={data.trendingSetups} activeTab={data.activeTab} />
+
 				{#if data.featuredSetups.length > 0}
 					<!-- Featured Setups -->
 					<section>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -62,6 +62,7 @@
 				<DiscoveryTabs
 					trendingSetups={data.trendingSetups}
 					forYouSetups={data.forYouSetups}
+					followingSetups={data.followingSetups}
 					activeTab={data.activeTab}
 				/>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -36,81 +36,105 @@
 
 {#if data.user}
 	<!-- Authenticated: Two-column dashboard -->
+	<!-- Mobile order controlled via CSS order; desktop placement via lg:col-start/row-start -->
 	<div class="mx-auto max-w-7xl px-4 py-6 lg:py-10">
-		<div class="flex flex-col gap-6 lg:grid lg:grid-cols-[280px_1fr]">
-			<!-- Left rail: identity -->
-			<aside class="flex flex-col gap-4">
+		<div class="grid grid-cols-1 gap-6 lg:grid-cols-[280px_1fr]">
+			<!-- ProfileCard: mobile order 1, desktop col-1 row-1 -->
+			<div class="order-1 lg:col-start-1 lg:row-start-1" data-testid="profile-card">
 				<ProfileCard
 					username={data.user.username}
 					avatarUrl={data.user.avatarUrl}
 					name={data.user.name ?? null}
 				/>
-				{#if data.userSetups.length === 0}
-					<ZeroStateCard />
-				{:else}
-					{#if data.userStats}
-						<StatsGrid stats={data.userStats} />
-					{/if}
-					<YourSetupsList setups={data.userSetups} username={data.user.username} />
-				{/if}
-				<QuickActions />
-				<AgentChips agents={data.userAgents} />
-			</aside>
+			</div>
 
-			<!-- Right column: discovery sections -->
-			<div class="flex flex-col gap-6">
+			<!-- Stats / Zero state: mobile order 2, desktop col-1 row-2 -->
+			<div class="order-2 lg:col-start-1 lg:row-start-2">
+				{#if data.userSetups.length === 0}
+					<div data-testid="zero-state-card"><ZeroStateCard /></div>
+				{:else if data.userStats}
+					<div data-testid="stats-grid"><StatsGrid stats={data.userStats} /></div>
+				{/if}
+			</div>
+
+			<!-- DiscoveryTabs: mobile order 3, desktop col-2 row-1 -->
+			<div class="order-3 lg:col-start-2 lg:row-start-1" data-testid="discovery-tabs">
 				<DiscoveryTabs
 					trendingSetups={data.trendingSetups}
 					forYouSetups={data.forYouSetups}
 					followingSetups={data.followingSetups}
 					activeTab={data.activeTab}
 				/>
+			</div>
 
-				<YourActivityPanel activity={data.yourActivity} username={data.user.username} />
+			<!-- YourSetupsList: mobile order 4, desktop col-1 row-3 (only when setups exist) -->
+			{#if data.userSetups.length > 0}
+				<div class="order-4 lg:col-start-1 lg:row-start-3" data-testid="your-setups-list">
+					<YourSetupsList setups={data.userSetups} username={data.user.username} />
+				</div>
+			{/if}
 
-				{#if data.featuredSetups.length > 0}
-					<!-- Featured Setups -->
-					<section>
-						<div class="mb-3 flex items-baseline justify-between">
-							<h2 class="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-								Featured
-							</h2>
-						</div>
-						<div class="flex flex-col gap-1.5">
-							{#each data.featuredSetups as setup (setup.id)}
-								<SetupCard {setup} username={setup.ownerUsername} showAuthor variant="compact" />
-							{/each}
-						</div>
-					</section>
-				{/if}
+			<!-- QuickActions: mobile order 5, desktop col-1 row-4 -->
+			<div class="order-5 lg:col-start-1 lg:row-start-4" data-testid="quick-actions">
+				<QuickActions />
+			</div>
 
-				<!-- Recently Added -->
-				<section>
+			<!-- AgentChips: mobile order 6, desktop col-1 row-5 (only when agents exist) -->
+			{#if data.userAgents.length > 0}
+				<div class="order-6 lg:col-start-1 lg:row-start-5" data-testid="agent-chips">
+					<AgentChips agents={data.userAgents} />
+				</div>
+			{/if}
+
+			<!-- Featured Setups: mobile order 7, desktop col-2 row-3 -->
+			{#if data.featuredSetups.length > 0}
+				<section class="order-7 lg:col-start-2 lg:row-start-3" data-testid="featured-setups">
 					<div class="mb-3 flex items-baseline justify-between">
 						<h2 class="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-							Recently Added
+							Featured
 						</h2>
-						<a
-							href="/explore"
-							class="text-xs text-muted-foreground transition-colors hover:text-foreground"
-						>
-							View all &rarr;
-						</a>
 					</div>
-
-					{#if data.recentSetups.length > 0}
-						<div class="flex flex-col gap-1.5">
-							{#each data.recentSetups as setup (setup.id)}
-								<SetupCard {setup} username={setup.ownerUsername} showAuthor variant="compact" />
-							{/each}
-						</div>
-					{:else}
-						<div class="rounded-lg border border-dashed border-border py-8 text-center">
-							<p class="text-sm text-muted-foreground">No setups yet. Be the first to share one!</p>
-						</div>
-					{/if}
+					<div class="flex flex-col gap-1.5">
+						{#each data.featuredSetups as setup (setup.id)}
+							<SetupCard {setup} username={setup.ownerUsername} showAuthor variant="compact" />
+						{/each}
+					</div>
 				</section>
-			</div>
+			{/if}
+
+			<!-- YourActivityPanel: mobile order 8, desktop col-2 row-2 -->
+			{#if data.yourActivity.length > 0}
+				<div class="order-8 lg:col-start-2 lg:row-start-2" data-testid="your-activity-panel">
+					<YourActivityPanel activity={data.yourActivity} username={data.user.username} />
+				</div>
+			{/if}
+
+			<!-- Recently Added: mobile order 9, desktop col-2 row-4 -->
+			<section class="order-9 lg:col-start-2 lg:row-start-4" data-testid="recently-added">
+				<div class="mb-3 flex items-baseline justify-between">
+					<h2 class="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+						Recently Added
+					</h2>
+					<a
+						href="/explore"
+						class="text-xs text-muted-foreground transition-colors hover:text-foreground"
+					>
+						View all &rarr;
+					</a>
+				</div>
+
+				{#if data.recentSetups.length > 0}
+					<div class="flex flex-col gap-1.5">
+						{#each data.recentSetups as setup (setup.id)}
+							<SetupCard {setup} username={setup.ownerUsername} showAuthor variant="compact" />
+						{/each}
+					</div>
+				{:else}
+					<div class="rounded-lg border border-dashed border-border py-8 text-center">
+						<p class="text-sm text-muted-foreground">No setups yet. Be the first to share one!</p>
+					</div>
+				{/if}
+			</section>
 		</div>
 	</div>
 {:else}

--- a/src/routes/homeDashboard.test.ts
+++ b/src/routes/homeDashboard.test.ts
@@ -9,12 +9,14 @@ const mockGetUserAggregateStats = vi.hoisted(() => vi.fn());
 const mockGetUserSetups = vi.hoisted(() => vi.fn());
 const mockGetUserSetupAgents = vi.hoisted(() => vi.fn());
 const mockGetActivityOnUserSetups = vi.hoisted(() => vi.fn());
+const mockGetForYouSetups = vi.hoisted(() => vi.fn());
 
 vi.mock('$lib/server/queries/setups', () => ({
 	getFeaturedSetups: mockGetFeaturedSetups,
 	getRecentSetups: mockGetRecentSetups,
 	getAgentsForSetups: mockGetAgentsForSetups,
 	getTrendingSetups: mockGetTrendingSetups,
+	getForYouSetups: mockGetForYouSetups,
 	searchSetups: vi.fn()
 }));
 
@@ -60,6 +62,7 @@ describe('home dashboard server load', () => {
 		mockGetUserSetups.mockResolvedValue([]);
 		mockGetUserSetupAgents.mockResolvedValue([]);
 		mockGetActivityOnUserSetups.mockResolvedValue([]);
+		mockGetForYouSetups.mockResolvedValue([]);
 	});
 
 	it('fetches featured setups with limit 3', async () => {

--- a/src/routes/homeDashboard.test.ts
+++ b/src/routes/homeDashboard.test.ts
@@ -6,6 +6,7 @@ const mockGetRecentSetups = vi.hoisted(() => vi.fn());
 const mockGetAgentsForSetups = vi.hoisted(() => vi.fn());
 const mockGetUserAggregateStats = vi.hoisted(() => vi.fn());
 const mockGetUserSetups = vi.hoisted(() => vi.fn());
+const mockGetUserSetupAgents = vi.hoisted(() => vi.fn());
 
 vi.mock('$lib/server/queries/setups', () => ({
 	getFeaturedSetups: mockGetFeaturedSetups,
@@ -17,7 +18,8 @@ vi.mock('$lib/server/queries/setups', () => ({
 
 vi.mock('$lib/server/queries/users', () => ({
 	getUserAggregateStats: mockGetUserAggregateStats,
-	getUserSetups: mockGetUserSetups
+	getUserSetups: mockGetUserSetups,
+	getUserSetupAgents: mockGetUserSetupAgents
 }));
 
 const makeSetup = (id: string) => ({
@@ -49,6 +51,7 @@ describe('home dashboard server load', () => {
 			followingCount: 0
 		});
 		mockGetUserSetups.mockResolvedValue([]);
+		mockGetUserSetupAgents.mockResolvedValue([]);
 	});
 
 	it('fetches featured setups with limit 3', async () => {

--- a/src/routes/homeDashboard.test.ts
+++ b/src/routes/homeDashboard.test.ts
@@ -10,6 +10,7 @@ const mockGetUserSetups = vi.hoisted(() => vi.fn());
 const mockGetUserSetupAgents = vi.hoisted(() => vi.fn());
 const mockGetActivityOnUserSetups = vi.hoisted(() => vi.fn());
 const mockGetForYouSetups = vi.hoisted(() => vi.fn());
+const mockGetSetupsFromFollowedUsers = vi.hoisted(() => vi.fn());
 
 vi.mock('$lib/server/queries/setups', () => ({
 	getFeaturedSetups: mockGetFeaturedSetups,
@@ -17,6 +18,7 @@ vi.mock('$lib/server/queries/setups', () => ({
 	getAgentsForSetups: mockGetAgentsForSetups,
 	getTrendingSetups: mockGetTrendingSetups,
 	getForYouSetups: mockGetForYouSetups,
+	getSetupsFromFollowedUsers: mockGetSetupsFromFollowedUsers,
 	searchSetups: vi.fn()
 }));
 
@@ -63,6 +65,7 @@ describe('home dashboard server load', () => {
 		mockGetUserSetupAgents.mockResolvedValue([]);
 		mockGetActivityOnUserSetups.mockResolvedValue([]);
 		mockGetForYouSetups.mockResolvedValue([]);
+		mockGetSetupsFromFollowedUsers.mockResolvedValue([]);
 	});
 
 	it('fetches featured setups with limit 3', async () => {

--- a/src/routes/homeDashboard.test.ts
+++ b/src/routes/homeDashboard.test.ts
@@ -8,6 +8,7 @@ const mockGetTrendingSetups = vi.hoisted(() => vi.fn());
 const mockGetUserAggregateStats = vi.hoisted(() => vi.fn());
 const mockGetUserSetups = vi.hoisted(() => vi.fn());
 const mockGetUserSetupAgents = vi.hoisted(() => vi.fn());
+const mockGetActivityOnUserSetups = vi.hoisted(() => vi.fn());
 
 vi.mock('$lib/server/queries/setups', () => ({
 	getFeaturedSetups: mockGetFeaturedSetups,
@@ -21,6 +22,10 @@ vi.mock('$lib/server/queries/users', () => ({
 	getUserAggregateStats: mockGetUserAggregateStats,
 	getUserSetups: mockGetUserSetups,
 	getUserSetupAgents: mockGetUserSetupAgents
+}));
+
+vi.mock('$lib/server/queries/activities', () => ({
+	getActivityOnUserSetups: mockGetActivityOnUserSetups
 }));
 
 const makeSetup = (id: string) => ({
@@ -54,6 +59,7 @@ describe('home dashboard server load', () => {
 		});
 		mockGetUserSetups.mockResolvedValue([]);
 		mockGetUserSetupAgents.mockResolvedValue([]);
+		mockGetActivityOnUserSetups.mockResolvedValue([]);
 	});
 
 	it('fetches featured setups with limit 3', async () => {

--- a/src/routes/homeDashboard.test.ts
+++ b/src/routes/homeDashboard.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const mockGetFeaturedSetups = vi.hoisted(() => vi.fn());
 const mockGetRecentSetups = vi.hoisted(() => vi.fn());
 const mockGetAgentsForSetups = vi.hoisted(() => vi.fn());
+const mockGetTrendingSetups = vi.hoisted(() => vi.fn());
 const mockGetUserAggregateStats = vi.hoisted(() => vi.fn());
 const mockGetUserSetups = vi.hoisted(() => vi.fn());
 const mockGetUserSetupAgents = vi.hoisted(() => vi.fn());
@@ -12,7 +13,7 @@ vi.mock('$lib/server/queries/setups', () => ({
 	getFeaturedSetups: mockGetFeaturedSetups,
 	getRecentSetups: mockGetRecentSetups,
 	getAgentsForSetups: mockGetAgentsForSetups,
-	getTrendingSetups: vi.fn(),
+	getTrendingSetups: mockGetTrendingSetups,
 	searchSetups: vi.fn()
 }));
 
@@ -44,6 +45,7 @@ describe('home dashboard server load', () => {
 		mockGetFeaturedSetups.mockResolvedValue([]);
 		mockGetRecentSetups.mockResolvedValue([]);
 		mockGetAgentsForSetups.mockResolvedValue({});
+		mockGetTrendingSetups.mockResolvedValue([]);
 		mockGetUserAggregateStats.mockResolvedValue({
 			setupsCount: 0,
 			starsReceived: 0,
@@ -58,7 +60,7 @@ describe('home dashboard server load', () => {
 		const { load } = await import('./+page.server');
 		mockGetFeaturedSetups.mockResolvedValue(makeSetups(3));
 
-		await load({ locals: { user: { id: 'u1' } } } as never);
+		await load({ locals: { user: { id: 'u1' } }, url: new URL('http://localhost/') } as never);
 
 		expect(mockGetFeaturedSetups).toHaveBeenCalledWith(3, 'u1');
 	});
@@ -67,17 +69,69 @@ describe('home dashboard server load', () => {
 		const { load } = await import('./+page.server');
 		mockGetRecentSetups.mockResolvedValue(makeSetups(3));
 
-		await load({ locals: { user: { id: 'u1' } } } as never);
+		await load({ locals: { user: { id: 'u1' } }, url: new URL('http://localhost/') } as never);
 
 		expect(mockGetRecentSetups).toHaveBeenCalledWith(3, 'u1');
 	});
 
-	it('does not return trendingSetups in authenticated response', async () => {
+	it('fetches trending setups with limit 6 for DiscoveryTabs', async () => {
 		const { load } = await import('./+page.server');
 
-		const result = await load({ locals: { user: { id: 'u1' } } } as never);
+		await load({ locals: { user: { id: 'u1' } }, url: new URL('http://localhost/') } as never);
 
-		expect(result).not.toHaveProperty('trendingSetups');
+		expect(mockGetTrendingSetups).toHaveBeenCalledWith(6, 'u1');
+	});
+
+	it('returns trendingSetups in authenticated response', async () => {
+		const { load } = await import('./+page.server');
+		mockGetTrendingSetups.mockResolvedValue([
+			{
+				...makeSetup('t1'),
+				ownerAvatarUrl: 'https://example.com/avatar.png',
+				agents: ['claude-code']
+			}
+		]);
+
+		const result = (await load({
+			locals: { user: { id: 'u1' } },
+			url: new URL('http://localhost/')
+		} as never)) as Record<string, unknown>;
+
+		expect(Array.isArray(result.trendingSetups)).toBe(true);
+		expect((result.trendingSetups as unknown[]).length).toBe(1);
+	});
+
+	it('defaults activeTab to for-you when no tab param', async () => {
+		const { load } = await import('./+page.server');
+
+		const result = (await load({
+			locals: { user: { id: 'u1' } },
+			url: new URL('http://localhost/')
+		} as never)) as Record<string, unknown>;
+
+		expect(result.activeTab).toBe('for-you');
+	});
+
+	it('sets activeTab to trending when ?tab=trending', async () => {
+		const { load } = await import('./+page.server');
+
+		const result = (await load({
+			locals: { user: { id: 'u1' } },
+			url: new URL('http://localhost/?tab=trending')
+		} as never)) as Record<string, unknown>;
+
+		expect(result.activeTab).toBe('trending');
+	});
+
+	it('falls back to for-you for invalid tab values', async () => {
+		const { load } = await import('./+page.server');
+
+		const result = (await load({
+			locals: { user: { id: 'u1' } },
+			url: new URL('http://localhost/?tab=invalid')
+		} as never)) as Record<string, unknown>;
+
+		expect(result.activeTab).toBe('for-you');
 	});
 
 	it('maps featured setups with ownerAvatarUrl undefined when null', async () => {
@@ -85,7 +139,8 @@ describe('home dashboard server load', () => {
 		mockGetFeaturedSetups.mockResolvedValue([makeSetup('x')]);
 
 		const result = (await load({
-			locals: { user: { id: 'u1' } }
+			locals: { user: { id: 'u1' } },
+			url: new URL('http://localhost/')
 		} as never)) as Record<string, unknown>;
 
 		const featured = result.featuredSetups as { ownerAvatarUrl: unknown }[];
@@ -101,7 +156,8 @@ describe('home dashboard server load', () => {
 		});
 
 		const result = (await load({
-			locals: { user: { id: 'u1' } }
+			locals: { user: { id: 'u1' } },
+			url: new URL('http://localhost/')
 		} as never)) as Record<string, unknown>;
 
 		const featured = result.featuredSetups as {
@@ -116,7 +172,8 @@ describe('home dashboard server load', () => {
 		mockGetRecentSetups.mockResolvedValue(makeSetups(3));
 
 		const result = (await load({
-			locals: { user: { id: 'u1' } }
+			locals: { user: { id: 'u1' } },
+			url: new URL('http://localhost/')
 		} as never)) as Record<string, unknown>;
 
 		expect((result.featuredSetups as unknown[]).length).toBe(3);

--- a/src/routes/homeDashboard.test.ts
+++ b/src/routes/homeDashboard.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Spy on the query functions to verify they are called with correct limits
+const mockGetFeaturedSetups = vi.hoisted(() => vi.fn());
+const mockGetRecentSetups = vi.hoisted(() => vi.fn());
+const mockGetAgentsForSetups = vi.hoisted(() => vi.fn());
+const mockGetUserAggregateStats = vi.hoisted(() => vi.fn());
+const mockGetUserSetups = vi.hoisted(() => vi.fn());
+
+vi.mock('$lib/server/queries/setups', () => ({
+	getFeaturedSetups: mockGetFeaturedSetups,
+	getRecentSetups: mockGetRecentSetups,
+	getAgentsForSetups: mockGetAgentsForSetups,
+	getTrendingSetups: vi.fn(),
+	searchSetups: vi.fn()
+}));
+
+vi.mock('$lib/server/queries/users', () => ({
+	getUserAggregateStats: mockGetUserAggregateStats,
+	getUserSetups: mockGetUserSetups
+}));
+
+const makeSetup = (id: string) => ({
+	id,
+	name: `setup-${id}`,
+	slug: `slug-${id}`,
+	description: `desc-${id}`,
+	display: null,
+	starsCount: 0,
+	clonesCount: 0,
+	updatedAt: new Date('2026-01-01'),
+	ownerUsername: 'alice',
+	ownerAvatarUrl: null,
+	agents: []
+});
+
+const makeSetups = (count: number) => Array.from({ length: count }, (_, i) => makeSetup(String(i)));
+
+describe('home dashboard server load', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetFeaturedSetups.mockResolvedValue([]);
+		mockGetRecentSetups.mockResolvedValue([]);
+		mockGetAgentsForSetups.mockResolvedValue({});
+		mockGetUserAggregateStats.mockResolvedValue({
+			setupsCount: 0,
+			starsReceived: 0,
+			clonesTotal: 0,
+			followingCount: 0
+		});
+		mockGetUserSetups.mockResolvedValue([]);
+	});
+
+	it('fetches featured setups with limit 3', async () => {
+		const { load } = await import('./+page.server');
+		mockGetFeaturedSetups.mockResolvedValue(makeSetups(3));
+
+		await load({ locals: { user: { id: 'u1' } } } as never);
+
+		expect(mockGetFeaturedSetups).toHaveBeenCalledWith(3, 'u1');
+	});
+
+	it('fetches recent setups with limit 3', async () => {
+		const { load } = await import('./+page.server');
+		mockGetRecentSetups.mockResolvedValue(makeSetups(3));
+
+		await load({ locals: { user: { id: 'u1' } } } as never);
+
+		expect(mockGetRecentSetups).toHaveBeenCalledWith(3, 'u1');
+	});
+
+	it('does not return trendingSetups in authenticated response', async () => {
+		const { load } = await import('./+page.server');
+
+		const result = await load({ locals: { user: { id: 'u1' } } } as never);
+
+		expect(result).not.toHaveProperty('trendingSetups');
+	});
+
+	it('maps featured setups with ownerAvatarUrl undefined when null', async () => {
+		const { load } = await import('./+page.server');
+		mockGetFeaturedSetups.mockResolvedValue([makeSetup('x')]);
+
+		const result = (await load({
+			locals: { user: { id: 'u1' } }
+		} as never)) as Record<string, unknown>;
+
+		const featured = result.featuredSetups as { ownerAvatarUrl: unknown }[];
+		expect(featured[0].ownerAvatarUrl).toBeUndefined();
+	});
+
+	it('maps featured setups with agents from agentsMap', async () => {
+		const { load } = await import('./+page.server');
+		const setup = makeSetup('s1');
+		mockGetFeaturedSetups.mockResolvedValue([setup]);
+		mockGetAgentsForSetups.mockResolvedValue({
+			s1: [{ id: 'a1', displayName: 'Claude', slug: 'claude-code' }]
+		});
+
+		const result = (await load({
+			locals: { user: { id: 'u1' } }
+		} as never)) as Record<string, unknown>;
+
+		const featured = result.featuredSetups as {
+			agents: { id: string; displayName: string; slug: string }[];
+		}[];
+		expect(featured[0].agents).toEqual([{ id: 'a1', displayName: 'Claude', slug: 'claude-code' }]);
+	});
+
+	it('returns featured and recent setups in authenticated response', async () => {
+		const { load } = await import('./+page.server');
+		mockGetFeaturedSetups.mockResolvedValue(makeSetups(3));
+		mockGetRecentSetups.mockResolvedValue(makeSetups(3));
+
+		const result = (await load({
+			locals: { user: { id: 'u1' } }
+		} as never)) as Record<string, unknown>;
+
+		expect((result.featuredSetups as unknown[]).length).toBe(3);
+		expect((result.recentSetups as unknown[]).length).toBe(3);
+	});
+});

--- a/src/routes/page.svelte.e2e.ts
+++ b/src/routes/page.svelte.e2e.ts
@@ -1,0 +1,469 @@
+import { expect, test } from '@playwright/test';
+
+// Tests require an authenticated session and a seeded database.
+// For auth, set up a global Playwright auth fixture that saves session cookies
+// to playwright/.auth/user.json (user with setups) and
+// playwright/.auth/zero-state-user.json (user with no setups).
+// Unauthenticated requests are redirected to GitHub OAuth; tests detect this
+// and skip gracefully when auth is not available.
+
+const HOME = '/';
+
+function isAuthRedirect(url: string): boolean {
+	return url.includes('/auth/login') || url.includes('github.com/login');
+}
+
+// ─── Logged-in happy path ─────────────────────────────────────────────────────
+
+test('happy path: profile card is visible when authenticated', async ({ page }) => {
+	await page.goto(HOME);
+	if (isAuthRedirect(page.url())) {
+		test.skip();
+		return;
+	}
+	await expect(page.getByTestId('profile-card')).toBeVisible();
+});
+
+test('happy path: discovery tabs section is visible', async ({ page }) => {
+	await page.goto(HOME);
+	if (isAuthRedirect(page.url())) {
+		test.skip();
+		return;
+	}
+	await expect(page.getByTestId('discovery-tabs')).toBeVisible();
+});
+
+test('happy path: quick actions section is visible', async ({ page }) => {
+	await page.goto(HOME);
+	if (isAuthRedirect(page.url())) {
+		test.skip();
+		return;
+	}
+	await expect(page.getByTestId('quick-actions')).toBeVisible();
+});
+
+test('happy path: recently added section is visible', async ({ page }) => {
+	await page.goto(HOME);
+	if (isAuthRedirect(page.url())) {
+		test.skip();
+		return;
+	}
+	await expect(page.getByTestId('recently-added')).toBeVisible();
+});
+
+test('happy path: stats grid shown when user has setups', async ({ page }) => {
+	await page.goto(HOME);
+	if (isAuthRedirect(page.url())) {
+		test.skip();
+		return;
+	}
+	const statsGrid = page.getByTestId('stats-grid');
+	const zeroState = page.getByTestId('zero-state-card');
+	// Exactly one of stats-grid or zero-state-card must be present
+	const statsVisible = await statsGrid.isVisible();
+	const zeroVisible = await zeroState.isVisible();
+	expect(statsVisible || zeroVisible).toBe(true);
+	expect(statsVisible && zeroVisible).toBe(false);
+});
+
+test('happy path: your setups list shown when user has setups', async ({ page }) => {
+	await page.goto(HOME);
+	if (isAuthRedirect(page.url())) {
+		test.skip();
+		return;
+	}
+	const statsGrid = page.getByTestId('stats-grid');
+	if (!(await statsGrid.isVisible())) {
+		// Zero-state user — skip happy-path assertion
+		test.skip();
+		return;
+	}
+	await expect(page.getByTestId('your-setups-list')).toBeVisible();
+});
+
+test('happy path: agent chips shown when user has agents', async ({ page }) => {
+	await page.goto(HOME);
+	if (isAuthRedirect(page.url())) {
+		test.skip();
+		return;
+	}
+	const statsGrid = page.getByTestId('stats-grid');
+	if (!(await statsGrid.isVisible())) {
+		test.skip();
+		return;
+	}
+	// AgentChips only renders when agents exist; presence is optional
+	const agentChips = page.getByTestId('agent-chips');
+	// If present in DOM, it must be visible
+	if ((await agentChips.count()) > 0) {
+		await expect(agentChips).toBeVisible();
+	}
+});
+
+test('happy path: activity panel shown when user has recent activity', async ({ page }) => {
+	await page.goto(HOME);
+	if (isAuthRedirect(page.url())) {
+		test.skip();
+		return;
+	}
+	const panel = page.getByTestId('your-activity-panel');
+	if ((await panel.count()) > 0) {
+		await expect(panel).toBeVisible();
+	}
+});
+
+// ─── Zero-state user ──────────────────────────────────────────────────────────
+
+test('zero-state: ZeroStateCard shown and StatsGrid absent when no setups', async ({ page }) => {
+	await page.goto(HOME);
+	if (isAuthRedirect(page.url())) {
+		test.skip();
+		return;
+	}
+	const zeroState = page.getByTestId('zero-state-card');
+	if (!(await zeroState.isVisible())) {
+		// Not a zero-state user — skip
+		test.skip();
+		return;
+	}
+	await expect(zeroState).toBeVisible();
+	await expect(page.getByTestId('stats-grid')).not.toBeVisible();
+});
+
+test('zero-state: YourSetupsList absent when no setups', async ({ page }) => {
+	await page.goto(HOME);
+	if (isAuthRedirect(page.url())) {
+		test.skip();
+		return;
+	}
+	const zeroState = page.getByTestId('zero-state-card');
+	if (!(await zeroState.isVisible())) {
+		test.skip();
+		return;
+	}
+	await expect(page.getByTestId('your-setups-list')).not.toBeVisible();
+});
+
+test('zero-state: AgentChips absent when user has no setups', async ({ page }) => {
+	await page.goto(HOME);
+	if (isAuthRedirect(page.url())) {
+		test.skip();
+		return;
+	}
+	const zeroState = page.getByTestId('zero-state-card');
+	if (!(await zeroState.isVisible())) {
+		test.skip();
+		return;
+	}
+	await expect(page.getByTestId('agent-chips')).not.toBeVisible();
+});
+
+test('zero-state: YourActivityPanel absent when user has no activity', async ({ page }) => {
+	await page.goto(HOME);
+	if (isAuthRedirect(page.url())) {
+		test.skip();
+		return;
+	}
+	const zeroState = page.getByTestId('zero-state-card');
+	if (!(await zeroState.isVisible())) {
+		test.skip();
+		return;
+	}
+	// Zero-state user has no setups and therefore no activity on those setups
+	await expect(page.getByTestId('your-activity-panel')).not.toBeVisible();
+});
+
+test('zero-state: Following tab shows empty state', async ({ page }) => {
+	await page.goto(`${HOME}?tab=following`);
+	if (isAuthRedirect(page.url())) {
+		test.skip();
+		return;
+	}
+	const zeroState = page.getByTestId('zero-state-card');
+	if (!(await zeroState.isVisible())) {
+		test.skip();
+		return;
+	}
+	// Following tab empty state shown when user doesn't follow anyone
+	await expect(page.getByTestId('discovery-tabs')).toBeVisible();
+	await expect(page.getByText('Follow people to see their setups here.')).toBeVisible();
+});
+
+test('zero-state: For You tab still renders content', async ({ page }) => {
+	await page.goto(`${HOME}?tab=for-you`);
+	if (isAuthRedirect(page.url())) {
+		test.skip();
+		return;
+	}
+	const zeroState = page.getByTestId('zero-state-card');
+	if (!(await zeroState.isVisible())) {
+		test.skip();
+		return;
+	}
+	// For You tab should show the tab nav (content may be empty-state or cards)
+	await expect(page.getByTestId('discovery-tabs')).toBeVisible();
+	await expect(page.getByRole('link', { name: 'For You' })).toBeVisible();
+});
+
+// ─── Tab switching ────────────────────────────────────────────────────────────
+
+test('tab switching: clicking Trending tab updates URL to ?tab=trending', async ({ page }) => {
+	await page.goto(HOME);
+	if (isAuthRedirect(page.url())) {
+		test.skip();
+		return;
+	}
+	await expect(page.getByTestId('discovery-tabs')).toBeVisible();
+	await page.getByRole('link', { name: 'Trending' }).click();
+	await expect(page).toHaveURL(/[?&]tab=trending/);
+});
+
+test('tab switching: clicking Following tab updates URL to ?tab=following', async ({ page }) => {
+	await page.goto(HOME);
+	if (isAuthRedirect(page.url())) {
+		test.skip();
+		return;
+	}
+	await expect(page.getByTestId('discovery-tabs')).toBeVisible();
+	await page.getByRole('link', { name: 'Following' }).click();
+	await expect(page).toHaveURL(/[?&]tab=following/);
+});
+
+test('tab switching: clicking For You tab updates URL to ?tab=for-you', async ({ page }) => {
+	await page.goto(`${HOME}?tab=trending`);
+	if (isAuthRedirect(page.url())) {
+		test.skip();
+		return;
+	}
+	await expect(page.getByTestId('discovery-tabs')).toBeVisible();
+	await page.getByRole('link', { name: 'For You' }).click();
+	await expect(page).toHaveURL(/[?&]tab=for-you/);
+});
+
+test('tab switching: Trending tab renders setup grid after switching', async ({ page }) => {
+	await page.goto(HOME);
+	if (isAuthRedirect(page.url())) {
+		test.skip();
+		return;
+	}
+	await page.getByRole('link', { name: 'Trending' }).click();
+	await expect(page).toHaveURL(/[?&]tab=trending/);
+	// After switching the tab content updates; discovery tabs section must still be visible
+	await expect(page.getByTestId('discovery-tabs')).toBeVisible();
+});
+
+// ─── Reload with ?tab=trending ────────────────────────────────────────────────
+
+test('reload: ?tab=trending loads with Trending tab active', async ({ page }) => {
+	await page.goto(`${HOME}?tab=trending`);
+	if (isAuthRedirect(page.url())) {
+		test.skip();
+		return;
+	}
+	const trendingLink = page.getByRole('link', { name: 'Trending' });
+	await expect(trendingLink).toHaveAttribute('aria-current', 'page');
+});
+
+test('reload: ?tab=following loads with Following tab active', async ({ page }) => {
+	await page.goto(`${HOME}?tab=following`);
+	if (isAuthRedirect(page.url())) {
+		test.skip();
+		return;
+	}
+	const followingLink = page.getByRole('link', { name: 'Following' });
+	await expect(followingLink).toHaveAttribute('aria-current', 'page');
+});
+
+test('reload: default (no ?tab) loads with For You tab active', async ({ page }) => {
+	await page.goto(HOME);
+	if (isAuthRedirect(page.url())) {
+		test.skip();
+		return;
+	}
+	const forYouLink = page.getByRole('link', { name: 'For You' });
+	await expect(forYouLink).toHaveAttribute('aria-current', 'page');
+});
+
+// ─── Mobile section order ─────────────────────────────────────────────────────
+
+test('mobile: ProfileCard appears above DiscoveryTabs', async ({ page, isMobile }) => {
+	test.skip(!isMobile, 'mobile-only test');
+	await page.goto(HOME);
+	if (isAuthRedirect(page.url())) {
+		test.skip();
+		return;
+	}
+
+	const profile = page.getByTestId('profile-card');
+	const discovery = page.getByTestId('discovery-tabs');
+	await expect(profile).toBeVisible();
+	await expect(discovery).toBeVisible();
+
+	const profileBox = await profile.boundingBox();
+	const discoveryBox = await discovery.boundingBox();
+	expect(profileBox).not.toBeNull();
+	expect(discoveryBox).not.toBeNull();
+	if (profileBox && discoveryBox) {
+		expect(profileBox.y).toBeLessThan(discoveryBox.y);
+	}
+});
+
+test('mobile: DiscoveryTabs appears above QuickActions', async ({ page, isMobile }) => {
+	test.skip(!isMobile, 'mobile-only test');
+	await page.goto(HOME);
+	if (isAuthRedirect(page.url())) {
+		test.skip();
+		return;
+	}
+
+	const discovery = page.getByTestId('discovery-tabs');
+	const quick = page.getByTestId('quick-actions');
+	await expect(discovery).toBeVisible();
+	await expect(quick).toBeVisible();
+
+	const discoveryBox = await discovery.boundingBox();
+	const quickBox = await quick.boundingBox();
+	expect(discoveryBox).not.toBeNull();
+	expect(quickBox).not.toBeNull();
+	if (discoveryBox && quickBox) {
+		expect(discoveryBox.y).toBeLessThan(quickBox.y);
+	}
+});
+
+test('mobile: DiscoveryTabs appears above YourSetupsList', async ({ page, isMobile }) => {
+	test.skip(!isMobile, 'mobile-only test');
+	await page.goto(HOME);
+	if (isAuthRedirect(page.url())) {
+		test.skip();
+		return;
+	}
+
+	const setupsList = page.getByTestId('your-setups-list');
+	if ((await setupsList.count()) === 0) {
+		// Zero-state user — YourSetupsList absent; skip this check
+		test.skip();
+		return;
+	}
+
+	const discovery = page.getByTestId('discovery-tabs');
+	await expect(discovery).toBeVisible();
+	await expect(setupsList).toBeVisible();
+
+	const discoveryBox = await discovery.boundingBox();
+	const setupsBox = await setupsList.boundingBox();
+	expect(discoveryBox).not.toBeNull();
+	expect(setupsBox).not.toBeNull();
+	if (discoveryBox && setupsBox) {
+		expect(discoveryBox.y).toBeLessThan(setupsBox.y);
+	}
+});
+
+test('mobile: QuickActions appears above RecentlyAdded', async ({ page, isMobile }) => {
+	test.skip(!isMobile, 'mobile-only test');
+	await page.goto(HOME);
+	if (isAuthRedirect(page.url())) {
+		test.skip();
+		return;
+	}
+
+	const quick = page.getByTestId('quick-actions');
+	const recent = page.getByTestId('recently-added');
+	await expect(quick).toBeVisible();
+	await expect(recent).toBeVisible();
+
+	const quickBox = await quick.boundingBox();
+	const recentBox = await recent.boundingBox();
+	expect(quickBox).not.toBeNull();
+	expect(recentBox).not.toBeNull();
+	if (quickBox && recentBox) {
+		expect(quickBox.y).toBeLessThan(recentBox.y);
+	}
+});
+
+test('mobile: Featured Setups appears above YourActivityPanel', async ({ page, isMobile }) => {
+	test.skip(!isMobile, 'mobile-only test');
+	await page.goto(HOME);
+	if (isAuthRedirect(page.url())) {
+		test.skip();
+		return;
+	}
+
+	const featured = page.getByTestId('featured-setups');
+	const activity = page.getByTestId('your-activity-panel');
+	if ((await featured.count()) === 0 || (await activity.count()) === 0) {
+		// One of the conditional sections is absent
+		test.skip();
+		return;
+	}
+
+	await expect(featured).toBeVisible();
+	await expect(activity).toBeVisible();
+
+	const featuredBox = await featured.boundingBox();
+	const activityBox = await activity.boundingBox();
+	expect(featuredBox).not.toBeNull();
+	expect(activityBox).not.toBeNull();
+	if (featuredBox && activityBox) {
+		expect(featuredBox.y).toBeLessThan(activityBox.y);
+	}
+});
+
+test('mobile: full section ordering — profile → stats → discovery → quick → recent', async ({
+	page,
+	isMobile
+}) => {
+	test.skip(!isMobile, 'mobile-only test');
+	await page.goto(HOME);
+	if (isAuthRedirect(page.url())) {
+		test.skip();
+		return;
+	}
+
+	const profile = page.getByTestId('profile-card');
+	const discovery = page.getByTestId('discovery-tabs');
+	const quick = page.getByTestId('quick-actions');
+	const recent = page.getByTestId('recently-added');
+
+	await expect(profile).toBeVisible();
+	await expect(discovery).toBeVisible();
+	await expect(quick).toBeVisible();
+	await expect(recent).toBeVisible();
+
+	const profileBox = await profile.boundingBox();
+	const discoveryBox = await discovery.boundingBox();
+	const quickBox = await quick.boundingBox();
+	const recentBox = await recent.boundingBox();
+
+	// Assert top-to-bottom ordering of key anchors
+	if (profileBox && discoveryBox) expect(profileBox.y).toBeLessThan(discoveryBox.y);
+	if (discoveryBox && quickBox) expect(discoveryBox.y).toBeLessThan(quickBox.y);
+	if (quickBox && recentBox) expect(quickBox.y).toBeLessThan(recentBox.y);
+});
+
+// ─── Desktop layout (sanity) ──────────────────────────────────────────────────
+
+test('desktop: two-column layout — profile card and discovery tabs side by side', async ({
+	page,
+	isMobile
+}) => {
+	test.skip(isMobile, 'desktop-only test');
+	await page.goto(HOME);
+	if (isAuthRedirect(page.url())) {
+		test.skip();
+		return;
+	}
+
+	const profile = page.getByTestId('profile-card');
+	const discovery = page.getByTestId('discovery-tabs');
+	await expect(profile).toBeVisible();
+	await expect(discovery).toBeVisible();
+
+	const profileBox = await profile.boundingBox();
+	const discoveryBox = await discovery.boundingBox();
+	expect(profileBox).not.toBeNull();
+	expect(discoveryBox).not.toBeNull();
+	if (profileBox && discoveryBox) {
+		// On desktop the two columns are side by side: discovery starts at a larger x
+		expect(discoveryBox.x).toBeGreaterThan(profileBox.x + profileBox.width - 1);
+	}
+});


### PR DESCRIPTION
## Summary

- test(ui): finalize mobile section ordering and add E2E spec (#337)
- feat(ui): fill DiscoveryTabs Following tab with getSetupsFromFollowedUsers (#335)
- feat(ui): fill DiscoveryTabs For You tab with getForYouSetups (#334)
- feat(ui): add YourActivityPanel with stars and clones on user setups (#336)
- feat(ui): add DiscoveryTabs shell and Trending tab to home dashboard (#333)
- feat(ui): add QuickActions and AgentChips to home dashboard left rail (#331)
- feat(ui): add compact card variant and right column base rows (#332)
- feat(ui): add home dashboard left rail identity core (#330)

Closes #330
Closes #332
Closes #331
Closes #333
Closes #336
Closes #334
Closes #335
Closes #337
Closes #329


## Test plan

See individual issue acceptance criteria for testing details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
