### PR TITLE
chore(cli): bump version to 0.6.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@coati/sh",
-	"version": "0.5.0",
+	"version": "0.6.0",
 	"description": "Coati CLI — clone, publish, and manage AI coding setups",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
Auto-generated by the CLI Release workflow.

`@coati/sh@0.6.0` has been published to npm and tag `cli-v0.6.0` has been pushed. This PR syncs `cli/package.json` on `main` so the next release computes the correct base version.

Merge with the **Create a merge commit** strategy to keep the tagged commit on main's history.