### PR TITLE
chore(seed): embed Clone on Coati badge in seed-setup README content (#362)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,43 +103,43 @@ The app will be running at [http://localhost:5173](http://localhost:5173).
 
 `.env.example` is the source of truth. The full list:
 
-| Variable                | Required     | Description                                                          |
-| ----------------------- | ------------ | -------------------------------------------------------------------- |
-| `DATABASE_URL`          | yes          | PostgreSQL connection string                                         |
-| `DATABASE_URL_TEST`     | dev/CI       | Test database connection string                                      |
-| `POSTGRES_USER`         | local Docker | Username for the Docker Postgres container                           |
-| `POSTGRES_PASSWORD`     | local Docker | Password for the Docker Postgres container                           |
-| `POSTGRES_DB`           | local Docker | Database name for the Docker Postgres container                      |
-| `GITHUB_CLIENT_ID`      | yes          | GitHub OAuth app client ID                                           |
-| `GITHUB_CLIENT_SECRET`  | yes          | GitHub OAuth app client secret                                       |
+| Variable                | Required     | Description                                                                 |
+| ----------------------- | ------------ | --------------------------------------------------------------------------- |
+| `DATABASE_URL`          | yes          | PostgreSQL connection string                                                |
+| `DATABASE_URL_TEST`     | dev/CI       | Test database connection string                                             |
+| `POSTGRES_USER`         | local Docker | Username for the Docker Postgres container                                  |
+| `POSTGRES_PASSWORD`     | local Docker | Password for the Docker Postgres container                                  |
+| `POSTGRES_DB`           | local Docker | Database name for the Docker Postgres container                             |
+| `GITHUB_CLIENT_ID`      | yes          | GitHub OAuth app client ID                                                  |
+| `GITHUB_CLIENT_SECRET`  | yes          | GitHub OAuth app client secret                                              |
 | `PUBLIC_SITE_URL`       | yes (prod)   | Canonical site URL used for OG tags and callbacks (e.g. `https://coati.sh`) |
-| `PUBLIC_ENV`            | prod         | `staging` or `production`; leave unset locally                       |
-| `PUBLIC_BETA_MODE`      | no           | Gate beta-only UI features                                           |
-| `PUBLIC_SENTRY_DSN`     | no           | Sentry DSN for error capture (omit to disable)                       |
-| `PUBLIC_APP_VERSION`    | no           | Injected at Docker build time from `package.json`                    |
-| `PUBLIC_MIXPANEL_TOKEN` | no           | Mixpanel project token (omit to disable analytics)                   |
+| `PUBLIC_ENV`            | prod         | `staging` or `production`; leave unset locally                              |
+| `PUBLIC_BETA_MODE`      | no           | Gate beta-only UI features                                                  |
+| `PUBLIC_SENTRY_DSN`     | no           | Sentry DSN for error capture (omit to disable)                              |
+| `PUBLIC_APP_VERSION`    | no           | Injected at Docker build time from `package.json`                           |
+| `PUBLIC_MIXPANEL_TOKEN` | no           | Mixpanel project token (omit to disable analytics)                          |
 
 ### Commands
 
-| Command                  | Description                                                |
-| ------------------------ | ---------------------------------------------------------- |
-| `pnpm dev`               | Start dev server on localhost:5173                         |
-| `pnpm build`             | Production build                                           |
-| `pnpm preview`           | Preview production build on :4173                          |
-| `pnpm check`             | TypeScript + svelte-check                                  |
-| `pnpm lint`              | Prettier check + ESLint                                    |
-| `pnpm format`            | Auto-format with Prettier                                  |
-| `pnpm test:unit`         | Vitest unit + component tests                              |
-| `pnpm test:coverage`     | Unit tests with coverage report                            |
-| `pnpm test:e2e`          | Playwright e2e tests (desktop + mobile)                    |
-| `pnpm test`              | Unit + e2e                                                 |
-| `pnpm ci:checks`         | Full CI pipeline: check + lint + test:unit                 |
-| `pnpm db:up`             | Start local PostgreSQL via Docker                          |
-| `pnpm db:down`           | Stop local PostgreSQL                                      |
-| `pnpm db:generate`       | Generate a new Drizzle migration from schema changes       |
-| `pnpm db:migrate`        | Apply pending migrations to the dev database               |
-| `pnpm db:migrate:test`   | Apply migrations to the test database                      |
-| `pnpm seed:dev`          | Seed the dev database with sample data                     |
+| Command                | Description                                          |
+| ---------------------- | ---------------------------------------------------- |
+| `pnpm dev`             | Start dev server on localhost:5173                   |
+| `pnpm build`           | Production build                                     |
+| `pnpm preview`         | Preview production build on :4173                    |
+| `pnpm check`           | TypeScript + svelte-check                            |
+| `pnpm lint`            | Prettier check + ESLint                              |
+| `pnpm format`          | Auto-format with Prettier                            |
+| `pnpm test:unit`       | Vitest unit + component tests                        |
+| `pnpm test:coverage`   | Unit tests with coverage report                      |
+| `pnpm test:e2e`        | Playwright e2e tests (desktop + mobile)              |
+| `pnpm test`            | Unit + e2e                                           |
+| `pnpm ci:checks`       | Full CI pipeline: check + lint + test:unit           |
+| `pnpm db:up`           | Start local PostgreSQL via Docker                    |
+| `pnpm db:down`         | Stop local PostgreSQL                                |
+| `pnpm db:generate`     | Generate a new Drizzle migration from schema changes |
+| `pnpm db:migrate`      | Apply pending migrations to the dev database         |
+| `pnpm db:migrate:test` | Apply migrations to the test database                |
+| `pnpm seed:dev`        | Seed the dev database with sample data               |
 
 ### Testing
 
@@ -199,24 +199,24 @@ All API routes live under `/api/v1/` and return consistent JSON:
 
 Selected endpoints (see `src/routes/api/v1/` for the complete list):
 
-| Endpoint                                         | Methods            | Description              |
-| ------------------------------------------------ | ------------------ | ------------------------ |
-| `/api/v1/setups`                                 | GET, POST          | List/search, create      |
-| `/api/v1/setups/[owner]/[slug]`                  | GET, PATCH, DELETE | Setup CRUD               |
-| `/api/v1/setups/[owner]/[slug]/files`            | GET                | Get files (for clone)    |
-| `/api/v1/setups/[owner]/[slug]/clone`            | POST               | Record clone + get files |
-| `/api/v1/setups/[owner]/[slug]/star`             | POST, DELETE       | Star / unstar            |
-| `/api/v1/setups/[owner]/[slug]/comments`         | GET, POST          | Comments                 |
-| `/api/v1/teams`                                  | GET, POST          | List/create teams        |
-| `/api/v1/teams/[slug]/members`                   | GET, POST          | Team membership          |
-| `/api/v1/teams/[slug]/invites`                   | GET, POST          | Team invites             |
-| `/api/v1/users/[username]`                       | GET                | User profile             |
-| `/api/v1/users/[username]/follow`                | POST, DELETE       | Follow / unfollow        |
-| `/api/v1/search`                                 | GET                | Global search            |
-| `/api/v1/feed`                                   | GET                | Activity feed            |
-| `/api/v1/auth/device`                            | POST               | CLI device auth start    |
-| `/api/v1/auth/device/poll`                       | POST               | CLI device auth poll     |
-| `/api/v1/health`                                 | GET                | Health check             |
+| Endpoint                                 | Methods            | Description              |
+| ---------------------------------------- | ------------------ | ------------------------ |
+| `/api/v1/setups`                         | GET, POST          | List/search, create      |
+| `/api/v1/setups/[owner]/[slug]`          | GET, PATCH, DELETE | Setup CRUD               |
+| `/api/v1/setups/[owner]/[slug]/files`    | GET                | Get files (for clone)    |
+| `/api/v1/setups/[owner]/[slug]/clone`    | POST               | Record clone + get files |
+| `/api/v1/setups/[owner]/[slug]/star`     | POST, DELETE       | Star / unstar            |
+| `/api/v1/setups/[owner]/[slug]/comments` | GET, POST          | Comments                 |
+| `/api/v1/teams`                          | GET, POST          | List/create teams        |
+| `/api/v1/teams/[slug]/members`           | GET, POST          | Team membership          |
+| `/api/v1/teams/[slug]/invites`           | GET, POST          | Team invites             |
+| `/api/v1/users/[username]`               | GET                | User profile             |
+| `/api/v1/users/[username]/follow`        | POST, DELETE       | Follow / unfollow        |
+| `/api/v1/search`                         | GET                | Global search            |
+| `/api/v1/feed`                           | GET                | Activity feed            |
+| `/api/v1/auth/device`                    | POST               | CLI device auth start    |
+| `/api/v1/auth/device/poll`               | POST               | CLI device auth poll     |
+| `/api/v1/health`                         | GET                | Health check             |
 
 ## Auth
 

--- a/cli/src/commands/publish.test.ts
+++ b/cli/src/commands/publish.test.ts
@@ -285,6 +285,17 @@ describe('create new setup (no id in manifest)', () => {
 		expect(ctx.io.success).toHaveBeenCalledWith(expect.stringContaining('published'));
 		expect(ctx.io.print).toHaveBeenCalledWith(expect.stringContaining('alice/my-setup'));
 	});
+
+	it('prints embed snippet after successful publish', async () => {
+		const program = makeProgram();
+		await program.parseAsync(['node', 'coati', 'publish']);
+
+		expect(ctx.io.print).toHaveBeenCalledWith(
+			expect.stringContaining(
+				'[![Clone on Coati](https://coati.sh/alice/my-setup/badge.svg)](https://coati.sh/alice/my-setup)'
+			)
+		);
+	});
 });
 
 // ── Branch 2: has id, owns it → PATCH /setups/{id} ────────────────────────────
@@ -332,6 +343,17 @@ describe('update existing setup (has id in manifest)', () => {
 
 		expect(ctx.io.success).toHaveBeenCalledWith(expect.stringContaining('updated'));
 		expect(ctx.io.print).toHaveBeenCalledWith(expect.stringContaining('alice/my-setup'));
+	});
+
+	it('prints embed snippet after successful update', async () => {
+		const program = makeProgram();
+		await program.parseAsync(['node', 'coati', 'publish']);
+
+		expect(ctx.io.print).toHaveBeenCalledWith(
+			expect.stringContaining(
+				'[![Clone on Coati](https://coati.sh/alice/my-setup/badge.svg)](https://coati.sh/alice/my-setup)'
+			)
+		);
 	});
 
 	it('does not write id back to coati.json on update', async () => {

--- a/cli/src/commands/publish.ts
+++ b/cli/src/commands/publish.ts
@@ -14,6 +14,7 @@ import {
 	type TeamInfo,
 	type PublishFileContent
 } from '../publish-payload.js';
+import { formatEmbedSnippet } from '../embed.js';
 
 interface PublishOptions {
 	json?: boolean;
@@ -401,6 +402,8 @@ export function registerPublish(program: Command, ctx: CommandContext): void {
 				ctx.io.print('');
 				ctx.io.success(`Setup ${isUpdate ? 'updated' : 'published'} successfully.`);
 				ctx.io.print(`  ${setupUrl}`);
+				ctx.io.print('');
+				ctx.io.print(formatEmbedSnippet(setupUrl));
 			}
 		});
 }

--- a/cli/src/embed.test.ts
+++ b/cli/src/embed.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { formatEmbedSnippet } from './embed.js';
+
+describe('formatEmbedSnippet', () => {
+	it('produces the correct markdown snippet with badge URL interpolated', () => {
+		const setupUrl = 'https://coati.sh/jimburch/fullstack-claude';
+		const result = formatEmbedSnippet(setupUrl);
+		expect(result).toContain(
+			'[![Clone on Coati](https://coati.sh/jimburch/fullstack-claude/badge.svg)](https://coati.sh/jimburch/fullstack-claude)'
+		);
+	});
+
+	it('derives badge URL by appending /badge.svg to setup URL', () => {
+		const setupUrl = 'https://coati.sh/alice/my-setup';
+		const result = formatEmbedSnippet(setupUrl);
+		expect(result).toContain('https://coati.sh/alice/my-setup/badge.svg');
+	});
+
+	it('includes an introductory sentence before the snippet', () => {
+		const setupUrl = 'https://coati.sh/alice/my-setup';
+		const result = formatEmbedSnippet(setupUrl);
+		const lines = result.split('\n');
+		expect(lines.length).toBeGreaterThan(1);
+		expect(lines[0]).not.toMatch(/^\[!/);
+		expect(lines[0].length).toBeGreaterThan(0);
+	});
+
+	it('returns a multi-line string', () => {
+		const result = formatEmbedSnippet('https://coati.sh/alice/my-setup');
+		expect(result).toContain('\n');
+	});
+});

--- a/cli/src/embed.ts
+++ b/cli/src/embed.ts
@@ -1,0 +1,8 @@
+export function formatEmbedSnippet(setupUrl: string): string {
+	const badgeUrl = `${setupUrl}/badge.svg`;
+	return [
+		'Add this badge to your README to let others clone your setup:',
+		'',
+		`  [![Clone on Coati](${badgeUrl})](${setupUrl})`
+	].join('\n');
+}

--- a/docs/LAUNCH-POSTS.md
+++ b/docs/LAUNCH-POSTS.md
@@ -357,7 +357,7 @@ Use this only in servers where you are already a regular. If you have not posted
 >
 > ### 3. READMEs carry more weight than file counts
 >
-> A setup without a README explaining the reasoning behind the configuration is a black box. The browse page surfaces README content, not file counts. The incentive is to explain *why* the setup is shaped the way it is, not to accumulate files.
+> A setup without a README explaining the reasoning behind the configuration is a black box. The browse page surfaces README content, not file counts. The incentive is to explain _why_ the setup is shaped the way it is, not to accumulate files.
 >
 > ## Stack
 >
@@ -417,44 +417,44 @@ The AI-tools space on Reddit is less one audience and more seven, each with a di
 
 ### Tier 1 — Primary targets (direct audience match)
 
-| Subreddit | Fit | Notes |
-| --- | --- | --- |
-| **r/ClaudeCode** | Perfect | This is the home audience. Lead here. |
-| **r/ClaudeAI** | Strong | Broader than CC but very tool-friendly. Post a day after r/ClaudeCode. |
-| **r/cursor** | Strong | Tailor the post to Cursor-specific capabilities. |
-| **r/ChatGPTCoding** | Strong | Emphasize multi-tool support. |
-| **r/GithubCopilot** | Good | Smaller, but high intent. |
-| **r/LLMDevs** | Good | Frame as a registry / package manager, not a "tool". |
-| **r/AI_Agents** | Good | Emphasize the manifest / packaging primitive. |
-| **r/PromptEngineering** | Moderate | Skills and CLAUDE.md angle lands here. |
-| **r/aipromptprogramming** | Moderate | Similar to above. |
-| **r/LocalLLaMA** | Moderate | Only if you have setups built around local/self-hosted models. They will downvote anything that feels API-only. |
+| Subreddit                 | Fit      | Notes                                                                                                           |
+| ------------------------- | -------- | --------------------------------------------------------------------------------------------------------------- |
+| **r/ClaudeCode**          | Perfect  | This is the home audience. Lead here.                                                                           |
+| **r/ClaudeAI**            | Strong   | Broader than CC but very tool-friendly. Post a day after r/ClaudeCode.                                          |
+| **r/cursor**              | Strong   | Tailor the post to Cursor-specific capabilities.                                                                |
+| **r/ChatGPTCoding**       | Strong   | Emphasize multi-tool support.                                                                                   |
+| **r/GithubCopilot**       | Good     | Smaller, but high intent.                                                                                       |
+| **r/LLMDevs**             | Good     | Frame as a registry / package manager, not a "tool".                                                            |
+| **r/AI_Agents**           | Good     | Emphasize the manifest / packaging primitive.                                                                   |
+| **r/PromptEngineering**   | Moderate | Skills and CLAUDE.md angle lands here.                                                                          |
+| **r/aipromptprogramming** | Moderate | Similar to above.                                                                                               |
+| **r/LocalLLaMA**          | Moderate | Only if you have setups built around local/self-hosted models. They will downvote anything that feels API-only. |
 
 ### Tier 2 — Broader developer audiences
 
-| Subreddit | Fit | Notes |
-| --- | --- | --- |
-| **r/programming** | Strong | Must be substantive, no hype. Read rules carefully — they ban self-promo in many forms. |
-| **r/webdev** | Good | Emphasize the full-stack SvelteKit build. |
-| **r/coding** | Moderate | Smaller, friendly. |
-| **r/devtools** | Strong | Exact fit. Post the HN writeup here. |
-| **r/SideProject** | Strong | Launch posts welcomed, but the community rewards substance. |
-| **r/commandline** | Good | Angle on the CLI specifically. |
-| **r/opensource** | Good | Angle on the project being open source and self-hostable. |
-| **r/selfhosted** | Moderate | Post only if you write specifically about running your own Coati instance. |
-| **r/coolgithubprojects** | Moderate | Low engagement but low friction. |
-| **r/InternetIsBeautiful** | Long shot | Only if the site itself has enough visual appeal to carry a non-technical audience. |
+| Subreddit                 | Fit       | Notes                                                                                   |
+| ------------------------- | --------- | --------------------------------------------------------------------------------------- |
+| **r/programming**         | Strong    | Must be substantive, no hype. Read rules carefully — they ban self-promo in many forms. |
+| **r/webdev**              | Good      | Emphasize the full-stack SvelteKit build.                                               |
+| **r/coding**              | Moderate  | Smaller, friendly.                                                                      |
+| **r/devtools**            | Strong    | Exact fit. Post the HN writeup here.                                                    |
+| **r/SideProject**         | Strong    | Launch posts welcomed, but the community rewards substance.                             |
+| **r/commandline**         | Good      | Angle on the CLI specifically.                                                          |
+| **r/opensource**          | Good      | Angle on the project being open source and self-hostable.                               |
+| **r/selfhosted**          | Moderate  | Post only if you write specifically about running your own Coati instance.              |
+| **r/coolgithubprojects**  | Moderate  | Low engagement but low friction.                                                        |
+| **r/InternetIsBeautiful** | Long shot | Only if the site itself has enough visual appeal to carry a non-technical audience.     |
 
 ### Tier 3 — Adjacent, post selectively
 
-| Subreddit | Fit | Notes |
-| --- | --- | --- |
-| **r/artificial** | Weak | Hobbyist audience, low technical depth. |
-| **r/OpenAI** | Weak | Off-tool. |
-| **r/MachineLearning** | Do not post | Research-only community. Launch posts get removed. |
-| **r/singularity** | Do not post | Reward function is hype. Coati is the wrong product for this crowd. |
-| **r/ChatGPT** | Do not post | General audience, not developers. |
-| **r/vibecoding** | Contrarian post only | Do not post a standard launch here. If you post at all, it should be a contrarian piece: "Coati is not for vibe-coded apps, here's why." Only do this if you want the discussion. |
+| Subreddit             | Fit                  | Notes                                                                                                                                                                             |
+| --------------------- | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **r/artificial**      | Weak                 | Hobbyist audience, low technical depth.                                                                                                                                           |
+| **r/OpenAI**          | Weak                 | Off-tool.                                                                                                                                                                         |
+| **r/MachineLearning** | Do not post          | Research-only community. Launch posts get removed.                                                                                                                                |
+| **r/singularity**     | Do not post          | Reward function is hype. Coati is the wrong product for this crowd.                                                                                                               |
+| **r/ChatGPT**         | Do not post          | General audience, not developers.                                                                                                                                                 |
+| **r/vibecoding**      | Contrarian post only | Do not post a standard launch here. If you post at all, it should be a contrarian piece: "Coati is not for vibe-coded apps, here's why." Only do this if you want the discussion. |
 
 ### Posting cadence
 
@@ -527,13 +527,13 @@ Every README that includes this badge is a permanent referral channel. Prioritiz
 
 ### HN day (primary launch)
 
-| Time | Action |
-| --- | --- |
-| 8:00 AM ET | Post Show HN |
-| 8:00–11:00 AM | Respond to every comment within minutes. Be technical, specific, honest. |
+| Time             | Action                                                                           |
+| ---------------- | -------------------------------------------------------------------------------- |
+| 8:00 AM ET       | Post Show HN                                                                     |
+| 8:00–11:00 AM    | Respond to every comment within minutes. Be technical, specific, honest.         |
 | 11:00 AM–2:00 PM | Continue monitoring, respond within 15 minutes. Share on Twitter that it's live. |
-| 2:00–6:00 PM | Post to r/ClaudeCode and r/cursor. Continue HN engagement. |
-| Evening | Wind down, but keep checking the HN thread every 30 minutes until bed. |
+| 2:00–6:00 PM     | Post to r/ClaudeCode and r/cursor. Continue HN engagement.                       |
+| Evening          | Wind down, but keep checking the HN thread every 30 minutes until bed.           |
 
 ### Reddit day 2
 

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
 		"clsx": "^2.1.1",
 		"drizzle-orm": "^0.45.1",
 		"isomorphic-dompurify": "^3.3.0",
+		"lru-cache": "^11.3.5",
 		"marked": "^17.0.4",
 		"mixpanel": "^0.18.0",
 		"mixpanel-browser": "^2.78.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       isomorphic-dompurify:
         specifier: ^3.3.0
         version: 3.3.0
+      lru-cache:
+        specifier: ^11.3.5
+        version: 11.3.5
       marked:
         specifier: ^17.0.4
         version: 17.0.4
@@ -3734,8 +3737,8 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
-  lru-cache@11.2.7:
-    resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
+  lru-cache@11.3.5:
+    resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
     engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
@@ -5216,7 +5219,7 @@ snapshots:
       '@csstools/css-color-parser': 4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-      lru-cache: 11.2.7
+      lru-cache: 11.3.5
 
   '@asamuzakjp/dom-selector@6.8.1':
     dependencies:
@@ -5224,7 +5227,7 @@ snapshots:
       bidi-js: 1.0.3
       css-tree: 3.2.1
       is-potential-custom-element-name: 1.0.1
-      lru-cache: 11.2.7
+      lru-cache: 11.3.5
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
@@ -7747,7 +7750,7 @@ snapshots:
       '@asamuzakjp/css-color': 5.0.1
       '@csstools/css-syntax-patches-for-csstree': 1.1.1(css-tree@3.2.1)
       css-tree: 3.2.1
-      lru-cache: 11.2.7
+      lru-cache: 11.3.5
 
   data-urls@7.0.0:
     dependencies:
@@ -8306,7 +8309,7 @@ snapshots:
 
   hosted-git-info@9.0.2:
     dependencies:
-      lru-cache: 11.2.7
+      lru-cache: 11.3.5
 
   html-encoding-sniffer@6.0.0:
     dependencies:
@@ -8669,7 +8672,7 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lru-cache@11.2.7: {}
+  lru-cache@11.3.5: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -8981,7 +8984,7 @@ snapshots:
 
   path-scurry@2.0.2:
     dependencies:
-      lru-cache: 11.2.7
+      lru-cache: 11.3.5
       minipass: 7.1.3
 
   path-type@4.0.0: {}

--- a/scripts/seed-dev.ts
+++ b/scripts/seed-dev.ts
@@ -123,7 +123,8 @@ export const GITHUB_USERNAMES = [
 	'jlongster',
 	'derickbailey',
 	'jakearchibald',
-	'marcosvega91'
+	'marcosvega91',
+	'jimburch'
 ];
 
 /**
@@ -1732,17 +1733,22 @@ function generateReadmeContent(
 	p: StackParams,
 	name: string,
 	description: string,
-	idx: number
+	idx: number,
+	username: string,
+	slug: string
 ): string | null {
+	const setupUrl = `https://coati.sh/${username}/${slug}`;
+	const badge = `[![Clone on Coati](${setupUrl}/badge.svg)](${setupUrl})`;
+
 	// 40% boilerplate
 	if (idx % 5 < 2) {
-		return `# ${name}\n\n${description}`;
+		return `# ${name}\n\n${description}\n\n${badge}\n`;
 	}
 
 	// 60% custom with varying depth
 	const depth = idx % 3; // 0 = short, 1 = medium, 2 = detailed
 
-	const lines = [`# ${name}`, '', description, ''];
+	const lines = [`# ${name}`, '', description, '', badge, ''];
 
 	if (depth >= 1) {
 		lines.push("## What's Included", '');
@@ -2607,6 +2613,300 @@ function pick<T>(arr: T[], count: number, offset: number): T[] {
 	return result;
 }
 
+/**
+ * Build the four primary launch-reference setups for the given owner user.
+ * These are always seeded with a badge in their README regardless of other logic.
+ */
+function buildPrimarySetups(
+	userId: string,
+	username: string
+): Array<GeneratedSetup & { userId: string }> {
+	const svelteParams = STACK_VARIATIONS[1]; // sveltekit typescript
+	const nextParams = STACK_VARIATIONS[0]; // next typescript
+	const expressParams = STACK_VARIATIONS[2]; // express typescript
+
+	const badge = (slug: string) => {
+		const setupUrl = `https://coati.sh/${username}/${slug}`;
+		return `[![Clone on Coati](${setupUrl}/badge.svg)](${setupUrl})`;
+	};
+
+	return [
+		{
+			userId,
+			name: 'Fullstack Claude',
+			slug: 'fullstack-claude',
+			description:
+				'Complete Claude Code setup for fullstack TypeScript development with SvelteKit, Drizzle ORM, and Lucia Auth. Includes instructions, commands, skills, and MCP servers.',
+			readme: [
+				'# Fullstack Claude',
+				'',
+				'Complete Claude Code setup for fullstack TypeScript development with SvelteKit, Drizzle ORM, and Lucia Auth.',
+				'',
+				badge('fullstack-claude'),
+				'',
+				"## What's Included",
+				'',
+				'- `CLAUDE.md` — project instructions covering SvelteKit conventions, Drizzle ORM patterns, and Lucia Auth',
+				'- `.claude/commands/` — dev, test, lint, and db-migrate commands',
+				'- `.claude/skills/tdd/` — red-green-refactor workflow',
+				'- `.mcp.json` — filesystem + PostgreSQL MCP servers pre-configured',
+				'- `.claude/hooks/pre-commit.sh` — lint + type-check before every commit',
+				'',
+				'## Usage',
+				'',
+				'```bash',
+				`coati clone ${username}/fullstack-claude`,
+				'```',
+				'',
+				'## Configuration',
+				'',
+				'After cloning, update the `DATABASE_URL` in `.mcp.json` to point at your local Postgres instance, then edit `CLAUDE.md` with your project name and any conventions specific to your codebase.',
+				''
+			].join('\n'),
+			category: 'web-dev' as const,
+			license: null,
+			starsCount: 128,
+			clonesCount: 47,
+			files: [
+				{
+					path: 'CLAUDE.md',
+					componentType: 'instruction' as const,
+					content: generateClaudeMd(svelteParams),
+					description: 'Project instructions and conventions',
+					agent: 'claude-code'
+				},
+				{
+					path: '.claude/settings.json',
+					componentType: 'config' as const,
+					content: generateSettingsJson(svelteParams, 'claude-code'),
+					description: 'Claude Code permission settings',
+					agent: 'claude-code'
+				},
+				{
+					path: '.mcp.json',
+					componentType: 'mcp_server' as const,
+					content: generateMcpJson(svelteParams),
+					description: 'MCP server configuration',
+					agent: 'claude-code'
+				},
+				{
+					path: '.claude/commands/dev.md',
+					componentType: 'command' as const,
+					content: generateCommandMd(svelteParams, 'dev'),
+					description: 'Start the dev server',
+					agent: 'claude-code'
+				},
+				{
+					path: '.claude/skills/tdd/SKILL.md',
+					componentType: 'skill' as const,
+					content: generateSkillMd(svelteParams, 'tdd'),
+					description: 'TDD red-green-refactor workflow',
+					agent: 'claude-code'
+				},
+				{
+					path: '.claude/hooks/pre-commit.sh',
+					componentType: 'hook' as const,
+					content: generateHookSh(svelteParams, 'pre-commit'),
+					description: 'Pre-commit lint and type check',
+					agent: 'claude-code'
+				}
+			],
+			tagNames: ['claude-code', 'typescript', 'sveltekit', 'tdd', 'web-dev'],
+			agentSlugs: ['claude-code']
+		},
+		{
+			userId,
+			name: 'Minimalist',
+			slug: 'minimalist',
+			description:
+				'Minimal Claude Code setup — just a CLAUDE.md with conventions and one TDD skill. No clutter.',
+			readme: [
+				'# Minimalist',
+				'',
+				'Minimal Claude Code setup — just a CLAUDE.md with conventions and one TDD skill. No clutter.',
+				'',
+				badge('minimalist'),
+				'',
+				"## What's Included",
+				'',
+				'- `CLAUDE.md` — concise project instructions',
+				'- `.claude/skills/tdd/SKILL.md` — TDD workflow',
+				'',
+				'## Philosophy',
+				'',
+				'Start minimal. Add files only when the need becomes obvious. A well-written CLAUDE.md outperforms a bloated setup every time.',
+				'',
+				'## Usage',
+				'',
+				'```bash',
+				`coati clone ${username}/minimalist`,
+				'```',
+				''
+			].join('\n'),
+			category: 'general' as const,
+			license: null,
+			starsCount: 84,
+			clonesCount: 31,
+			files: [
+				{
+					path: 'CLAUDE.md',
+					componentType: 'instruction' as const,
+					content: generateClaudeMd(nextParams),
+					description: 'Minimal project instructions',
+					agent: 'claude-code'
+				},
+				{
+					path: '.claude/skills/tdd/SKILL.md',
+					componentType: 'skill' as const,
+					content: generateSkillMd(nextParams, 'tdd'),
+					description: 'TDD workflow',
+					agent: 'claude-code'
+				}
+			],
+			tagNames: ['claude-code', 'typescript'],
+			agentSlugs: ['claude-code']
+		},
+		{
+			userId,
+			name: 'MCP Power User',
+			slug: 'mcp-power-user',
+			description:
+				'MCP-heavy setup with filesystem, PostgreSQL, and web search servers configured. For teams that want Claude deeply integrated into their toolchain.',
+			readme: [
+				'# MCP Power User',
+				'',
+				'MCP-heavy setup with filesystem, PostgreSQL, and web search servers configured. For teams that want Claude deeply integrated into their toolchain.',
+				'',
+				badge('mcp-power-user'),
+				'',
+				"## What's Included",
+				'',
+				'- `.mcp.json` — filesystem, PostgreSQL, and web-search MCP servers',
+				'- `CLAUDE.md` — instructions optimized for MCP-assisted workflows',
+				'- `.claude/commands/` — dev and test commands',
+				'- `.claude/skills/api-design/SKILL.md` — API design patterns',
+				'',
+				'## Usage',
+				'',
+				'```bash',
+				`coati clone ${username}/mcp-power-user`,
+				'```',
+				'',
+				'## Configuration',
+				'',
+				'Edit `.mcp.json` to set your `DATABASE_URL` and any API keys needed by the web-search server.',
+				''
+			].join('\n'),
+			category: 'web-dev' as const,
+			license: null,
+			starsCount: 63,
+			clonesCount: 22,
+			files: [
+				{
+					path: 'CLAUDE.md',
+					componentType: 'instruction' as const,
+					content: generateClaudeMd(expressParams),
+					description: 'MCP-oriented project instructions',
+					agent: 'claude-code'
+				},
+				{
+					path: '.mcp.json',
+					componentType: 'mcp_server' as const,
+					content: generateMcpJson(expressParams),
+					description: 'MCP server configuration',
+					agent: 'claude-code'
+				},
+				{
+					path: '.claude/commands/dev.md',
+					componentType: 'command' as const,
+					content: generateCommandMd(expressParams, 'dev'),
+					description: 'Start the dev server',
+					agent: 'claude-code'
+				},
+				{
+					path: '.claude/skills/api-design/SKILL.md',
+					componentType: 'skill' as const,
+					content: generateSkillMd(expressParams, 'api-design'),
+					description: 'API design patterns',
+					agent: 'claude-code'
+				}
+			],
+			tagNames: ['claude-code', 'typescript', 'mcp', 'api'],
+			agentSlugs: ['claude-code']
+		},
+		{
+			userId,
+			name: 'TypeScript Fullstack Starter',
+			slug: 'typescript-fullstack-starter',
+			description:
+				'TypeScript fullstack starter covering Next.js, Cursor, and Copilot in one unified setup. Great baseline for new projects.',
+			readme: [
+				'# TypeScript Fullstack Starter',
+				'',
+				'TypeScript fullstack starter covering Next.js, Cursor, and Copilot in one unified setup. Great baseline for new projects.',
+				'',
+				badge('typescript-fullstack-starter'),
+				'',
+				"## What's Included",
+				'',
+				'- `CLAUDE.md` — Next.js TypeScript conventions',
+				'- `.cursorrules` + `.cursor/rules/` — Cursor rules for components and testing',
+				'- `.github/copilot-instructions.md` — Copilot team instructions',
+				'- `.vscode/settings.json` — shared editor config',
+				'- `scripts/setup.sh` — one-command project setup',
+				'',
+				'## Usage',
+				'',
+				'```bash',
+				`coati clone ${username}/typescript-fullstack-starter`,
+				'```',
+				''
+			].join('\n'),
+			category: 'web-dev' as const,
+			license: null,
+			starsCount: 97,
+			clonesCount: 38,
+			files: [
+				{
+					path: 'CLAUDE.md',
+					componentType: 'instruction' as const,
+					content: generateClaudeMd(nextParams),
+					description: 'Next.js TypeScript instructions',
+					agent: 'claude-code'
+				},
+				{
+					path: '.cursorrules',
+					componentType: 'instruction' as const,
+					content: generateCursorrules(nextParams),
+					description: 'Cursor global rules',
+					agent: 'cursor'
+				},
+				{
+					path: '.github/copilot-instructions.md',
+					componentType: 'instruction' as const,
+					content: generateCopilotInstructions(nextParams, 'team'),
+					description: 'Copilot team instructions',
+					agent: 'copilot'
+				},
+				{
+					path: '.vscode/settings.json',
+					componentType: 'config' as const,
+					content: generateVscodeSettings(nextParams),
+					description: 'VS Code settings'
+				},
+				{
+					path: 'scripts/setup.sh',
+					componentType: 'setup_script' as const,
+					content: generateSetupScript(nextParams),
+					description: 'Project setup script'
+				}
+			],
+			tagNames: ['claude-code', 'cursor', 'copilot', 'typescript', 'nextjs', 'web-dev'],
+			agentSlugs: ['claude-code', 'cursor', 'copilot']
+		}
+	];
+}
+
 /** Generate all setup data for seeding. */
 export function generateSetups(
 	seedUsers: Array<{ id: string; username: string }>,
@@ -2632,12 +2932,21 @@ export function generateSetups(
 		}
 	}
 
+	// Add the four primary launch-reference setups for the jimburch user (or first user)
+	const primaryOwner =
+		usersWithSetups.find((u) => u.username.toLowerCase() === 'jimburch') ?? usersWithSetups[0];
+	if (primaryOwner) {
+		for (const ps of buildPrimarySetups(primaryOwner.id, primaryOwner.username)) {
+			generated.push(ps);
+		}
+	}
+
 	return generated;
 }
 
 function buildSetup(
 	userId: string,
-	_username: string,
+	username: string,
 	idx: number,
 	seedTags: Array<{ id: string; name: string }>,
 	templates: AgentTemplate[]
@@ -2704,7 +3013,7 @@ function buildSetup(
 	const files = template.generateFiles(params);
 
 	// Generate readme
-	const readme = generateReadmeContent(params, name, description, idx);
+	const readme = generateReadmeContent(params, name, description, idx, username, slug);
 
 	return {
 		userId,

--- a/src/lib/components/BadgeEmbed.svelte
+++ b/src/lib/components/BadgeEmbed.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+	import CodeBlock from '$lib/components/CodeBlock.svelte';
+
+	interface Props {
+		badgeUrl: string;
+		setupUrl: string;
+	}
+
+	const { badgeUrl, setupUrl }: Props = $props();
+
+	const snippet = $derived(`[![Clone on Coati](${badgeUrl})](${setupUrl})`);
+	let open = $state(false);
+	let copied = $state(false);
+
+	function copySnippet() {
+		navigator.clipboard.writeText(snippet);
+		copied = true;
+		setTimeout(() => (copied = false), 2000);
+	}
+</script>
+
+<div>
+	<button
+		onclick={() => (open = !open)}
+		class="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+		aria-expanded={open}
+		aria-label="Embed this setup"
+		data-testid="embed-toggle-btn"
+	>
+		<svg class="size-3.5" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+			<path
+				d="M0 1.75A.75.75 0 0 1 .75 1h4.253c1.227 0 2.317.59 3 1.501A3.743 3.743 0 0 1 11.006 1h4.245a.75.75 0 0 1 .75.75v10.5a.75.75 0 0 1-.75.75h-4.507a2.25 2.25 0 0 0-1.591.659l-.622.621a.75.75 0 0 1-1.06 0l-.622-.621A2.25 2.25 0 0 0 5.258 13H.75a.75.75 0 0 1-.75-.75Zm7.251 10.324.004-5.073-.002-2.253A2.25 2.25 0 0 0 5.003 2.5H1.5v9h3.757a3.75 3.75 0 0 1 1.994.574ZM8.755 4.75l-.004 7.322a3.752 3.752 0 0 1 1.992-.572H14.5v-9h-3.495a2.25 2.25 0 0 0-2.25 2.25Z"
+			/>
+		</svg>
+		Embed
+	</button>
+
+	{#if open}
+		<div
+			class="mt-3 space-y-3 rounded-lg border border-border bg-card p-3"
+			data-testid="embed-panel"
+		>
+			<!-- Live badge preview -->
+			<div>
+				<p class="mb-1.5 text-xs font-medium text-muted-foreground">Preview</p>
+				<img src={badgeUrl} alt="Clone on Coati badge" class="h-5" />
+			</div>
+
+			<!-- Markdown snippet via CodeBlock -->
+			<div>
+				<p class="mb-1.5 text-xs font-medium text-muted-foreground">Markdown</p>
+				<CodeBlock code={snippet} label="Markdown" />
+			</div>
+
+			<!-- Copy snippet button (CloneCommand-style interaction) -->
+			<button
+				onclick={copySnippet}
+				class="flex w-full items-center justify-center gap-1.5 rounded-md border border-border bg-secondary px-3 py-1.5 text-sm hover:bg-secondary/80"
+				aria-label={copied ? 'Copied!' : 'Copy embed snippet'}
+				data-testid="copy-snippet-btn"
+			>
+				{#if copied}
+					<svg class="size-4 text-green-500" viewBox="0 0 16 16" fill="currentColor">
+						<path
+							d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.75.75 0 0 1 1.06-1.06L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z"
+						/>
+					</svg>
+					Copied!
+				{:else}
+					<svg class="size-4 text-muted-foreground" viewBox="0 0 16 16" fill="currentColor">
+						<path
+							d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"
+						/>
+						<path
+							d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"
+						/>
+					</svg>
+					Copy snippet
+				{/if}
+			</button>
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/BadgeEmbed.test.ts
+++ b/src/lib/components/BadgeEmbed.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Pure logic extracted from BadgeEmbed.svelte for unit testing
+
+function buildEmbedSnippet(badgeUrl: string, setupUrl: string): string {
+	return `[![Clone on Coati](${badgeUrl})](${setupUrl})`;
+}
+
+function copyEmbedSnippet(text: string, clipboard: { writeText: (t: string) => Promise<void> }) {
+	return clipboard.writeText(text);
+}
+
+function scheduleReset(
+	onReset: () => void,
+	delay: number,
+	timer: { setTimeout: (fn: () => void, ms: number) => ReturnType<typeof setTimeout> }
+): ReturnType<typeof setTimeout> {
+	return timer.setTimeout(onReset, delay);
+}
+
+// ─── buildEmbedSnippet ────────────────────────────────────────────────────────
+
+describe('buildEmbedSnippet', () => {
+	it('interpolates badge URL and setup URL into the markdown snippet', () => {
+		const badgeUrl = 'https://coati.dev/jimburch/claude-code-pro/badge.svg';
+		const setupUrl = 'https://coati.dev/jimburch/claude-code-pro';
+		expect(buildEmbedSnippet(badgeUrl, setupUrl)).toBe(
+			'[![Clone on Coati](https://coati.dev/jimburch/claude-code-pro/badge.svg)](https://coati.dev/jimburch/claude-code-pro)'
+		);
+	});
+
+	it('uses the literal alt text "Clone on Coati"', () => {
+		const snippet = buildEmbedSnippet('https://example.com/badge.svg', 'https://example.com');
+		expect(snippet).toContain('![Clone on Coati]');
+	});
+
+	it('wraps the badge image in a link to the setup URL', () => {
+		const setupUrl = 'https://coati.dev/alice/my-setup';
+		const snippet = buildEmbedSnippet('https://coati.dev/alice/my-setup/badge.svg', setupUrl);
+		expect(snippet).toMatch(/\]\(https:\/\/coati\.dev\/alice\/my-setup\)$/);
+	});
+
+	it('works for team setup URLs', () => {
+		const badgeUrl = 'https://coati.dev/org/my-team/my-setup/badge.svg';
+		const setupUrl = 'https://coati.dev/org/my-team/my-setup';
+		expect(buildEmbedSnippet(badgeUrl, setupUrl)).toBe(
+			'[![Clone on Coati](https://coati.dev/org/my-team/my-setup/badge.svg)](https://coati.dev/org/my-team/my-setup)'
+		);
+	});
+
+	it('produces valid markdown image-link syntax', () => {
+		const snippet = buildEmbedSnippet('https://x.dev/badge.svg', 'https://x.dev/setup');
+		// Must start with [![
+		expect(snippet.startsWith('[![')).toBe(true);
+		// Must contain the closing link paren at the end
+		expect(snippet.endsWith(')')).toBe(true);
+	});
+});
+
+// ─── copyEmbedSnippet ─────────────────────────────────────────────────────────
+
+describe('copyEmbedSnippet', () => {
+	it('calls clipboard.writeText with the exact snippet', async () => {
+		const writeText = vi.fn().mockResolvedValue(undefined);
+		const snippet = buildEmbedSnippet(
+			'https://coati.dev/jimburch/setup/badge.svg',
+			'https://coati.dev/jimburch/setup'
+		);
+		await copyEmbedSnippet(snippet, { writeText });
+		expect(writeText).toHaveBeenCalledWith(snippet);
+	});
+
+	it('calls clipboard.writeText exactly once per invocation', async () => {
+		const writeText = vi.fn().mockResolvedValue(undefined);
+		await copyEmbedSnippet('some snippet', { writeText });
+		expect(writeText).toHaveBeenCalledTimes(1);
+	});
+
+	it('passes the full snippet string verbatim, including special characters', async () => {
+		const writeText = vi.fn().mockResolvedValue(undefined);
+		const snippet = '[![Clone on Coati](https://coati.dev/u/s/badge.svg)](https://coati.dev/u/s)';
+		await copyEmbedSnippet(snippet, { writeText });
+		expect(writeText).toHaveBeenCalledWith(snippet);
+	});
+});
+
+// ─── scheduleReset ────────────────────────────────────────────────────────────
+
+describe('scheduleReset', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('calls onReset after 2000ms', () => {
+		const onReset = vi.fn();
+		scheduleReset(onReset, 2000, { setTimeout: globalThis.setTimeout });
+		expect(onReset).not.toHaveBeenCalled();
+		vi.advanceTimersByTime(2000);
+		expect(onReset).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not call onReset before the delay elapses', () => {
+		const onReset = vi.fn();
+		scheduleReset(onReset, 2000, { setTimeout: globalThis.setTimeout });
+		vi.advanceTimersByTime(1999);
+		expect(onReset).not.toHaveBeenCalled();
+	});
+
+	it('calls onReset exactly once after delay', () => {
+		const onReset = vi.fn();
+		scheduleReset(onReset, 2000, { setTimeout: globalThis.setTimeout });
+		vi.advanceTimersByTime(5000);
+		expect(onReset).toHaveBeenCalledTimes(1);
+	});
+
+	it('returns a handle that can cancel the reset', () => {
+		const onReset = vi.fn();
+		const handle = scheduleReset(onReset, 2000, { setTimeout: globalThis.setTimeout });
+		clearTimeout(handle);
+		vi.advanceTimersByTime(2000);
+		expect(onReset).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/components/SetupSidebar.svelte
+++ b/src/lib/components/SetupSidebar.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
+	import { page } from '$app/state';
 	import CloneCommand from '$lib/components/CloneCommand.svelte';
+	import BadgeEmbed from '$lib/components/BadgeEmbed.svelte';
 	import DeleteSetupDialog from '$lib/components/DeleteSetupDialog.svelte';
 	import { Button } from '$lib/components/ui/button';
 
@@ -33,6 +35,9 @@
 
 	const isFeatured = $derived(localFeatured !== null ? localFeatured : !!setup.featuredAt);
 	const showReport = $derived(isLoggedIn && !isOwner);
+
+	const badgeUrl = $derived(`${page.url.origin}/${ownerUsername}/${setup.slug}/badge.svg`);
+	const setupUrl = $derived(`${page.url.origin}/${ownerUsername}/${setup.slug}`);
 </script>
 
 <aside class="w-full shrink-0 lg:w-64" data-testid="sidebar">
@@ -41,6 +46,9 @@
 		<div class="hidden lg:block">
 			<h3 class="mb-2 text-sm font-semibold text-muted-foreground">Clone</h3>
 			<CloneCommand username={ownerUsername} slug={setup.slug} />
+			<div class="mt-2">
+				<BadgeEmbed {badgeUrl} {setupUrl} />
+			</div>
 		</div>
 
 		<!-- Tags -->

--- a/src/lib/server/badge-cache.test.ts
+++ b/src/lib/server/badge-cache.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { LRUCache } from 'lru-cache';
+
+// Use a fresh LRUCache instance in each test rather than the module singleton,
+// so that tests are isolated and TTL / capacity behaviour can be verified
+// without coupling to the shared cache state.
+//
+// lru-cache uses performance.now() internally, which vi.useFakeTimers() does
+// not intercept by default. Passing `perf: { now: () => Date.now() }` routes
+// all time reads through Date.now(), which IS mocked by vi.useFakeTimers().
+
+describe('badge cache', () => {
+	const MAX = 3;
+	const TTL = 500; // ms
+	let cache: LRUCache<string, string>;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		cache = new LRUCache<string, string>({
+			max: MAX,
+			ttl: TTL,
+			perf: { now: () => Date.now() }
+		});
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('get returns the value set for a key (cache hit)', () => {
+		cache.set('alice/my-setup', '<svg>available</svg>');
+		expect(cache.get('alice/my-setup')).toBe('<svg>available</svg>');
+	});
+
+	it('get returns undefined for a key that was never set (cache miss)', () => {
+		expect(cache.get('nobody/nothing')).toBeUndefined();
+	});
+
+	it('caches the unavailable SVG the same as the available SVG', () => {
+		cache.set('alice/private', '<svg>unavailable</svg>');
+		expect(cache.get('alice/private')).toBe('<svg>unavailable</svg>');
+	});
+
+	it('entry is undefined after the TTL has elapsed', () => {
+		cache.set('alice/my-setup', '<svg>available</svg>');
+		vi.advanceTimersByTime(TTL + 1);
+		expect(cache.get('alice/my-setup')).toBeUndefined();
+	});
+
+	it('entry is still present before the TTL elapses', () => {
+		cache.set('alice/my-setup', '<svg>available</svg>');
+		vi.advanceTimersByTime(TTL - 1);
+		expect(cache.get('alice/my-setup')).toBe('<svg>available</svg>');
+	});
+
+	it('evicts the least-recently-used entry when capacity is exceeded', () => {
+		cache.set('a/1', 'svg1');
+		cache.set('b/2', 'svg2');
+		cache.set('c/3', 'svg3');
+		// Access a/1 and b/2 to make c/3 the LRU
+		cache.get('a/1');
+		cache.get('b/2');
+		// Adding a fourth entry evicts the LRU (c/3)
+		cache.set('d/4', 'svg4');
+		expect(cache.get('c/3')).toBeUndefined();
+		expect(cache.get('a/1')).toBe('svg1');
+		expect(cache.get('b/2')).toBe('svg2');
+		expect(cache.get('d/4')).toBe('svg4');
+	});
+
+	it('getBadge / setBadge module exports behave consistently', async () => {
+		// Import the real module to verify the exported API shape without mutating
+		// the shared singleton (we just check the function signatures exist).
+		const mod = await import('./badge-cache');
+		expect(typeof mod.getBadge).toBe('function');
+		expect(typeof mod.setBadge).toBe('function');
+		expect(mod.CACHE_MAX).toBeGreaterThan(0);
+		expect(mod.CACHE_TTL_MS).toBe(5 * 60 * 1_000);
+	});
+});

--- a/src/lib/server/badge-cache.ts
+++ b/src/lib/server/badge-cache.ts
@@ -1,0 +1,19 @@
+import { LRUCache } from 'lru-cache';
+
+const CACHE_MAX = 5_000;
+const CACHE_TTL_MS = 5 * 60 * 1_000;
+
+const cache = new LRUCache<string, string>({
+	max: CACHE_MAX,
+	ttl: CACHE_TTL_MS
+});
+
+export function getBadge(key: string): string | undefined {
+	return cache.get(key);
+}
+
+export function setBadge(key: string, svg: string): void {
+	cache.set(key, svg);
+}
+
+export { CACHE_MAX, CACHE_TTL_MS };

--- a/src/lib/server/badge.ts
+++ b/src/lib/server/badge.ts
@@ -1,0 +1,26 @@
+const COATI_MARK = `<g transform="translate(6,6) scale(0.2)" fill="white" aria-hidden="true">
+    <path d="M 72,14 C 90,14 96,30 96,50 C 96,72 80,90 58,92 C 36,94 16,80 10,60 C 4,40 14,18 32,10 L 35,20 C 22,26 15,40 19,55 C 23,70 37,80 53,79 C 69,78 82,66 82,50 C 82,35 76,23 65,20 Z"/>
+    <path d="M 28,12 C 34,9 40,8 40,8 L 37,18 C 37,18 31,19 26,22 Z" fill-opacity="0.45"/>
+    <path d="M 14,30 C 12,36 10,44 11,50 L 21,48 C 20,44 21,38 22,33 Z" fill-opacity="0.45"/>
+    <path d="M 14,62 C 17,70 23,77 30,82 L 34,73 C 29,69 25,64 23,58 Z" fill-opacity="0.45"/>
+    <path d="M 44,88 C 50,91 57,92 63,91 L 60,81 C 55,82 50,82 45,79 Z" fill-opacity="0.45"/>
+    <circle cx="70" cy="18" r="14"/>
+    <circle cx="60" cy="7" r="5"/>
+    <path d="M 80,15 L 96,19 L 80,25 Z"/>
+  </g>`;
+
+export const BADGE_AVAILABLE = `<svg xmlns="http://www.w3.org/2000/svg" width="160" height="32" role="img" aria-label="Clone on Coati">
+  <title>Clone on Coati</title>
+  <rect width="160" height="32" rx="4" fill="#1a9e72"/>
+  ${COATI_MARK}
+  <rect x="31" y="6" width="1" height="20" fill="white" fill-opacity="0.3"/>
+  <text x="40" y="21" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="12" fill="white">Clone on Coati</text>
+</svg>`;
+
+export const BADGE_UNAVAILABLE = `<svg xmlns="http://www.w3.org/2000/svg" width="184" height="32" role="img" aria-label="Setup unavailable">
+  <title>Setup unavailable</title>
+  <rect width="184" height="32" rx="4" fill="#6b7280"/>
+  ${COATI_MARK}
+  <rect x="31" y="6" width="1" height="20" fill="white" fill-opacity="0.3"/>
+  <text x="40" y="21" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="12" fill="white">Setup unavailable</text>
+</svg>`;

--- a/src/lib/server/queries/badgeState.integration.test.ts
+++ b/src/lib/server/queries/badgeState.integration.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Integration tests for getBadgeState.
+ *
+ * Hits the real database — no mocks. Requires a running PostgreSQL instance
+ * pointed to by DATABASE_URL_TEST (preferred) or DATABASE_URL. When neither
+ * is set the entire suite is skipped so that the CI unit-test run is unaffected.
+ *
+ * Pattern mirrors src/lib/server/queries/setups.integration.test.ts.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+vi.mock('$env/dynamic/private', () => ({
+	env: {
+		DATABASE_URL:
+			process.env.DATABASE_URL_TEST ??
+			process.env.DATABASE_URL ??
+			'postgresql://coati:coati@localhost:5432/coati_dev',
+		GITHUB_CLIENT_ID: 'test',
+		GITHUB_CLIENT_SECRET: 'test'
+	}
+}));
+
+import { db } from '$lib/server/db';
+import { setups } from '$lib/server/db/schema';
+import { eq } from 'drizzle-orm';
+import { getBadgeState } from './badgeState';
+import { createTestUser, createTestSetup, deleteTestUsers } from './__tests__/db-test-helpers';
+
+const hasDatabase = !!(process.env.DATABASE_URL_TEST ?? process.env.DATABASE_URL);
+
+describe.skipIf(!hasDatabase)('getBadgeState — integration', () => {
+	const createdUserIds: string[] = [];
+
+	afterEach(async () => {
+		await deleteTestUsers(createdUserIds.splice(0));
+	});
+
+	it('returns available for a public setup', async () => {
+		const user = await createTestUser();
+		const setup = await createTestSetup(user.id);
+		createdUserIds.push(user.id);
+
+		const state = await getBadgeState(user.username, setup.slug);
+		expect(state).toBe('available');
+	});
+
+	it('returns unavailable for a private setup', async () => {
+		const user = await createTestUser();
+		const setup = await createTestSetup(user.id);
+		createdUserIds.push(user.id);
+
+		await db.update(setups).set({ visibility: 'private' }).where(eq(setups.id, setup.id));
+
+		const state = await getBadgeState(user.username, setup.slug);
+		expect(state).toBe('unavailable');
+	});
+
+	it('returns unavailable when the slug does not exist', async () => {
+		const state = await getBadgeState('nonexistent-user-xyz', 'nonexistent-slug-xyz');
+		expect(state).toBe('unavailable');
+	});
+});

--- a/src/lib/server/queries/badgeState.ts
+++ b/src/lib/server/queries/badgeState.ts
@@ -1,6 +1,6 @@
 import { and, eq } from 'drizzle-orm';
 import { db } from '$lib/server/db';
-import { setups, users } from '$lib/server/db/schema';
+import { setups, teams, users } from '$lib/server/db/schema';
 
 export type BadgeState = 'available' | 'unavailable';
 
@@ -10,6 +10,20 @@ export async function getBadgeState(ownerUsername: string, slug: string): Promis
 		.from(setups)
 		.innerJoin(users, eq(setups.userId, users.id))
 		.where(and(eq(users.username, ownerUsername), eq(setups.slug, slug)))
+		.limit(1);
+
+	if (rows.length === 0 || rows[0].visibility !== 'public') {
+		return 'unavailable';
+	}
+	return 'available';
+}
+
+export async function getTeamBadgeState(teamSlug: string, setupSlug: string): Promise<BadgeState> {
+	const rows = await db
+		.select({ visibility: setups.visibility })
+		.from(setups)
+		.innerJoin(teams, eq(setups.teamId, teams.id))
+		.where(and(eq(teams.slug, teamSlug), eq(setups.slug, setupSlug)))
 		.limit(1);
 
 	if (rows.length === 0 || rows[0].visibility !== 'public') {

--- a/src/lib/server/queries/badgeState.ts
+++ b/src/lib/server/queries/badgeState.ts
@@ -1,0 +1,19 @@
+import { and, eq } from 'drizzle-orm';
+import { db } from '$lib/server/db';
+import { setups, users } from '$lib/server/db/schema';
+
+export type BadgeState = 'available' | 'unavailable';
+
+export async function getBadgeState(ownerUsername: string, slug: string): Promise<BadgeState> {
+	const rows = await db
+		.select({ visibility: setups.visibility })
+		.from(setups)
+		.innerJoin(users, eq(setups.userId, users.id))
+		.where(and(eq(users.username, ownerUsername), eq(setups.slug, slug)))
+		.limit(1);
+
+	if (rows.length === 0 || rows[0].visibility !== 'public') {
+		return 'unavailable';
+	}
+	return 'available';
+}

--- a/src/lib/server/queries/teamBadgeState.integration.test.ts
+++ b/src/lib/server/queries/teamBadgeState.integration.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Integration tests for getTeamBadgeState.
+ *
+ * Hits the real database — no mocks. Requires a running PostgreSQL instance
+ * pointed to by DATABASE_URL_TEST (preferred) or DATABASE_URL. When neither
+ * is set the entire suite is skipped so that the CI unit-test run is unaffected.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+vi.mock('$env/dynamic/private', () => ({
+	env: {
+		DATABASE_URL:
+			process.env.DATABASE_URL_TEST ??
+			process.env.DATABASE_URL ??
+			'postgresql://coati:coati@localhost:5432/coati_dev',
+		GITHUB_CLIENT_ID: 'test',
+		GITHUB_CLIENT_SECRET: 'test'
+	}
+}));
+
+import { db } from '$lib/server/db';
+import { setups, teams } from '$lib/server/db/schema';
+import { eq, inArray } from 'drizzle-orm';
+import { getTeamBadgeState } from './badgeState';
+import { createTestUser, createTestSetup, deleteTestUsers } from './__tests__/db-test-helpers';
+
+const hasDatabase = !!(process.env.DATABASE_URL_TEST ?? process.env.DATABASE_URL);
+
+let _seq = 0;
+function uid(): string {
+	return `${Date.now()}-${++_seq}-${Math.floor(Math.random() * 10000)}`;
+}
+
+async function createTestTeam(ownerId: string): Promise<{ id: string; slug: string }> {
+	const id = uid();
+	const [team] = await db
+		.insert(teams)
+		.values({
+			name: `Test Team ${id}`,
+			slug: `test-team-${id}`,
+			ownerId
+		})
+		.returning();
+	return team;
+}
+
+async function deleteTestTeams(teamIds: string[]): Promise<void> {
+	if (teamIds.length === 0) return;
+	await db.delete(teams).where(inArray(teams.id, teamIds));
+}
+
+describe.skipIf(!hasDatabase)('getTeamBadgeState — integration', () => {
+	const createdUserIds: string[] = [];
+	const createdTeamIds: string[] = [];
+
+	afterEach(async () => {
+		await deleteTestUsers(createdUserIds.splice(0));
+		await deleteTestTeams(createdTeamIds.splice(0));
+	});
+
+	it('returns available for a public team setup', async () => {
+		const user = await createTestUser();
+		createdUserIds.push(user.id);
+		const team = await createTestTeam(user.id);
+		createdTeamIds.push(team.id);
+		const setup = await createTestSetup(user.id);
+		await db.update(setups).set({ teamId: team.id }).where(eq(setups.id, setup.id));
+
+		const state = await getTeamBadgeState(team.slug, setup.slug);
+		expect(state).toBe('available');
+	});
+
+	it('returns unavailable for a private team setup', async () => {
+		const user = await createTestUser();
+		createdUserIds.push(user.id);
+		const team = await createTestTeam(user.id);
+		createdTeamIds.push(team.id);
+		const setup = await createTestSetup(user.id);
+		await db
+			.update(setups)
+			.set({ teamId: team.id, visibility: 'private' })
+			.where(eq(setups.id, setup.id));
+
+		const state = await getTeamBadgeState(team.slug, setup.slug);
+		expect(state).toBe('unavailable');
+	});
+
+	it('returns unavailable when team slug does not exist', async () => {
+		const state = await getTeamBadgeState('nonexistent-team-xyz', 'nonexistent-slug-xyz');
+		expect(state).toBe('unavailable');
+	});
+
+	it('returns unavailable when setup slug does not exist for a valid team', async () => {
+		const user = await createTestUser();
+		createdUserIds.push(user.id);
+		const team = await createTestTeam(user.id);
+		createdTeamIds.push(team.id);
+
+		const state = await getTeamBadgeState(team.slug, 'nonexistent-slug-xyz');
+		expect(state).toBe('unavailable');
+	});
+});

--- a/src/lib/server/seed-dev.test.ts
+++ b/src/lib/server/seed-dev.test.ts
@@ -204,6 +204,55 @@ describe('generateSetups', () => {
 		}
 		expect(generateTagNames()).toEqual(generateTagNames());
 	});
+
+	it('every non-null README includes the Clone on Coati badge markdown', () => {
+		const manyUsers = makeUsers(35);
+		const setups = generateSetups(manyUsers, tags, agents);
+
+		const withReadme = setups.filter((s) => s.readme !== null);
+		expect(withReadme.length).toBeGreaterThan(0);
+
+		for (const setup of withReadme) {
+			expect(setup.readme).toContain('[![Clone on Coati]');
+			expect(setup.readme).toContain('https://coati.sh/');
+			expect(setup.readme).toContain('/badge.svg');
+		}
+	});
+
+	it('includes the four primary launch-reference setups with correct badge READMEs', () => {
+		const manyUsers = makeUsers(35);
+		const setups = generateSetups(manyUsers, tags, agents);
+
+		// Primary setups are assigned to user0 when no jimburch user is present
+		const primaryOwnerUsername = 'user0';
+		const primarySlugs = [
+			'fullstack-claude',
+			'minimalist',
+			'mcp-power-user',
+			'typescript-fullstack-starter'
+		];
+
+		for (const slug of primarySlugs) {
+			const found = setups.find((s) => s.slug === slug);
+			expect(found, `primary setup ${slug} missing from fleet`).toBeDefined();
+			expect(found!.readme).not.toBeNull();
+			expect(found!.readme).toContain('[![Clone on Coati]');
+			expect(found!.readme).toContain(`https://coati.sh/${primaryOwnerUsername}/${slug}/badge.svg`);
+		}
+	});
+
+	it('primary setup with jimburch uses jimburch in badge URL', () => {
+		const usersWithJimburch = [
+			...makeUsers(5),
+			{ id: 'jimburch-id', username: 'jimburch' },
+			{ id: 'last-user', username: 'lastuser' } // this one gets no setups
+		];
+		const setups = generateSetups(usersWithJimburch, tags, agents);
+
+		const fullstack = setups.find((s) => s.slug === 'fullstack-claude');
+		expect(fullstack).toBeDefined();
+		expect(fullstack!.readme).toContain('https://coati.sh/jimburch/fullstack-claude/badge.svg');
+	});
 });
 
 // ─── fetchGitHubProfile / fetchGitHubProfiles ────────────────────────────────

--- a/src/routes/(public)/[username]/[slug]/badge.svg/+server.ts
+++ b/src/routes/(public)/[username]/[slug]/badge.svg/+server.ts
@@ -1,0 +1,27 @@
+import type { RequestHandler } from './$types';
+import { BADGE_AVAILABLE, BADGE_UNAVAILABLE } from '$lib/server/badge';
+import { getBadge, setBadge } from '$lib/server/badge-cache';
+import { getBadgeState } from '$lib/server/queries/badgeState';
+
+const CACHE_CONTROL = 'public, max-age=300, s-maxage=300, stale-while-revalidate=86400';
+
+export const GET: RequestHandler = async ({ params }) => {
+	const { username, slug } = params;
+	const cacheKey = `${username}/${slug}`;
+
+	let svg = getBadge(cacheKey);
+
+	if (svg === undefined) {
+		const state = await getBadgeState(username, slug);
+		svg = state === 'available' ? BADGE_AVAILABLE : BADGE_UNAVAILABLE;
+		setBadge(cacheKey, svg);
+	}
+
+	return new Response(svg, {
+		status: 200,
+		headers: {
+			'Content-Type': 'image/svg+xml; charset=utf-8',
+			'Cache-Control': CACHE_CONTROL
+		}
+	});
+};

--- a/src/routes/(public)/[username]/[slug]/badge.svg/badge-svg.test.ts
+++ b/src/routes/(public)/[username]/[slug]/badge.svg/badge-svg.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetBadgeState = vi.fn();
+const mockGetBadge = vi.fn();
+const mockSetBadge = vi.fn();
+
+vi.mock('$lib/server/queries/badgeState', () => ({
+	getBadgeState: (...args: unknown[]) => mockGetBadgeState(...args)
+}));
+
+vi.mock('$lib/server/badge-cache', () => ({
+	getBadge: (...args: unknown[]) => mockGetBadge(...args),
+	setBadge: (...args: unknown[]) => mockSetBadge(...args)
+}));
+
+vi.mock('$lib/server/badge', () => ({
+	BADGE_AVAILABLE: '<svg>available</svg>',
+	BADGE_UNAVAILABLE: '<svg>unavailable</svg>'
+}));
+
+function makeGetEvent(username: string, slug: string) {
+	return {
+		params: { username, slug },
+		request: new Request(`http://localhost/${username}/${slug}/badge.svg`)
+	} as Parameters<(typeof import('./+server'))['GET']>[0];
+}
+
+describe('GET /:username/:slug/badge.svg', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('returns 200 with image/svg+xml content-type', async () => {
+		mockGetBadge.mockReturnValue(undefined);
+		mockGetBadgeState.mockResolvedValue('available');
+		const { GET } = await import('./+server');
+		const res = await GET(makeGetEvent('alice', 'my-setup'));
+		expect(res.status).toBe(200);
+		expect(res.headers.get('Content-Type')).toBe('image/svg+xml; charset=utf-8');
+	});
+
+	it('returns BADGE_AVAILABLE body when setup is public', async () => {
+		mockGetBadge.mockReturnValue(undefined);
+		mockGetBadgeState.mockResolvedValue('available');
+		const { GET } = await import('./+server');
+		const res = await GET(makeGetEvent('alice', 'my-setup'));
+		expect(await res.text()).toBe('<svg>available</svg>');
+	});
+
+	it('returns BADGE_UNAVAILABLE body when setup is private', async () => {
+		mockGetBadge.mockReturnValue(undefined);
+		mockGetBadgeState.mockResolvedValue('unavailable');
+		const { GET } = await import('./+server');
+		const res = await GET(makeGetEvent('alice', 'private-setup'));
+		expect(await res.text()).toBe('<svg>unavailable</svg>');
+	});
+
+	it('returns BADGE_UNAVAILABLE body when setup does not exist', async () => {
+		mockGetBadge.mockReturnValue(undefined);
+		mockGetBadgeState.mockResolvedValue('unavailable');
+		const { GET } = await import('./+server');
+		const res = await GET(makeGetEvent('nobody', 'nothing'));
+		expect(await res.text()).toBe('<svg>unavailable</svg>');
+	});
+
+	it('includes the correct Cache-Control header', async () => {
+		mockGetBadge.mockReturnValue(undefined);
+		mockGetBadgeState.mockResolvedValue('available');
+		const { GET } = await import('./+server');
+		const res = await GET(makeGetEvent('alice', 'my-setup'));
+		expect(res.headers.get('Cache-Control')).toBe(
+			'public, max-age=300, s-maxage=300, stale-while-revalidate=86400'
+		);
+	});
+
+	it('returns 200 (not 4xx) even when setup is unavailable', async () => {
+		mockGetBadge.mockReturnValue(undefined);
+		mockGetBadgeState.mockResolvedValue('unavailable');
+		const { GET } = await import('./+server');
+		const res = await GET(makeGetEvent('nobody', 'ghost'));
+		expect(res.status).toBe(200);
+	});
+
+	it('serves the cached SVG without calling getBadgeState on a cache hit', async () => {
+		mockGetBadge.mockReturnValue('<svg>cached</svg>');
+		const { GET } = await import('./+server');
+		const res = await GET(makeGetEvent('alice', 'my-setup'));
+		expect(await res.text()).toBe('<svg>cached</svg>');
+		expect(mockGetBadgeState).not.toHaveBeenCalled();
+	});
+
+	it('caches the resolved SVG on a cache miss', async () => {
+		mockGetBadge.mockReturnValue(undefined);
+		mockGetBadgeState.mockResolvedValue('available');
+		const { GET } = await import('./+server');
+		await GET(makeGetEvent('alice', 'my-setup'));
+		expect(mockSetBadge).toHaveBeenCalledWith('alice/my-setup', '<svg>available</svg>');
+	});
+
+	it('uses username/slug as the cache key', async () => {
+		mockGetBadge.mockReturnValue(undefined);
+		mockGetBadgeState.mockResolvedValue('unavailable');
+		const { GET } = await import('./+server');
+		await GET(makeGetEvent('bob', 'cool-setup'));
+		expect(mockGetBadge).toHaveBeenCalledWith('bob/cool-setup');
+		expect(mockSetBadge).toHaveBeenCalledWith('bob/cool-setup', '<svg>unavailable</svg>');
+	});
+});

--- a/src/routes/(public)/org/[teamSlug]/[setupSlug]/+page.svelte
+++ b/src/routes/(public)/org/[teamSlug]/[setupSlug]/+page.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+	import { page } from '$app/state';
 	import OgMeta from '$lib/components/OgMeta.svelte';
 	import SetupFileList from '$lib/components/SetupFileList.svelte';
 	import CloneCommand from '$lib/components/CloneCommand.svelte';
+	import BadgeEmbed from '$lib/components/BadgeEmbed.svelte';
 	import ReadmeSection from '$lib/components/ReadmeSection.svelte';
 	import { Avatar, AvatarImage, AvatarFallback } from '$lib/components/ui/avatar';
 	import AgentIcon from '$lib/components/AgentIcon.svelte';
@@ -17,6 +19,8 @@
 	});
 
 	const filesBasePath = $derived(`/org/${team.slug}/${setup.slug}/files`);
+	const badgeUrl = $derived(`${page.url.origin}/org/${team.slug}/${setup.slug}/badge.svg`);
+	const setupUrl = $derived(`${page.url.origin}/org/${team.slug}/${setup.slug}`);
 </script>
 
 <svelte:head>
@@ -133,6 +137,9 @@
 				<div class="hidden lg:block">
 					<h3 class="mb-2 text-sm font-semibold text-muted-foreground">Clone</h3>
 					<CloneCommand username={setup.ownerUsername} slug={setup.slug} />
+					<div class="mt-2">
+						<BadgeEmbed {badgeUrl} {setupUrl} />
+					</div>
 				</div>
 
 				<!-- Tags -->

--- a/src/routes/(public)/org/[teamSlug]/[setupSlug]/badge.svg/+server.ts
+++ b/src/routes/(public)/org/[teamSlug]/[setupSlug]/badge.svg/+server.ts
@@ -1,0 +1,27 @@
+import type { RequestHandler } from './$types';
+import { BADGE_AVAILABLE, BADGE_UNAVAILABLE } from '$lib/server/badge';
+import { getBadge, setBadge } from '$lib/server/badge-cache';
+import { getTeamBadgeState } from '$lib/server/queries/badgeState';
+
+const CACHE_CONTROL = 'public, max-age=300, s-maxage=300, stale-while-revalidate=86400';
+
+export const GET: RequestHandler = async ({ params }) => {
+	const { teamSlug, setupSlug } = params;
+	const cacheKey = `team:${teamSlug}/${setupSlug}`;
+
+	let svg = getBadge(cacheKey);
+
+	if (svg === undefined) {
+		const state = await getTeamBadgeState(teamSlug, setupSlug);
+		svg = state === 'available' ? BADGE_AVAILABLE : BADGE_UNAVAILABLE;
+		setBadge(cacheKey, svg);
+	}
+
+	return new Response(svg, {
+		status: 200,
+		headers: {
+			'Content-Type': 'image/svg+xml; charset=utf-8',
+			'Cache-Control': CACHE_CONTROL
+		}
+	});
+};

--- a/src/routes/(public)/org/[teamSlug]/[setupSlug]/badge.svg/badge-svg.test.ts
+++ b/src/routes/(public)/org/[teamSlug]/[setupSlug]/badge.svg/badge-svg.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetTeamBadgeState = vi.fn();
+const mockGetBadge = vi.fn();
+const mockSetBadge = vi.fn();
+
+vi.mock('$lib/server/queries/badgeState', () => ({
+	getTeamBadgeState: (...args: unknown[]) => mockGetTeamBadgeState(...args)
+}));
+
+vi.mock('$lib/server/badge-cache', () => ({
+	getBadge: (...args: unknown[]) => mockGetBadge(...args),
+	setBadge: (...args: unknown[]) => mockSetBadge(...args)
+}));
+
+vi.mock('$lib/server/badge', () => ({
+	BADGE_AVAILABLE: '<svg>available</svg>',
+	BADGE_UNAVAILABLE: '<svg>unavailable</svg>'
+}));
+
+function makeGetEvent(teamSlug: string, setupSlug: string) {
+	return {
+		params: { teamSlug, setupSlug },
+		request: new Request(`http://localhost/org/${teamSlug}/${setupSlug}/badge.svg`)
+	} as Parameters<(typeof import('./+server'))['GET']>[0];
+}
+
+describe('GET /org/:teamSlug/:setupSlug/badge.svg', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('returns 200 with image/svg+xml content-type', async () => {
+		mockGetBadge.mockReturnValue(undefined);
+		mockGetTeamBadgeState.mockResolvedValue('available');
+		const { GET } = await import('./+server');
+		const res = await GET(makeGetEvent('my-org', 'my-setup'));
+		expect(res.status).toBe(200);
+		expect(res.headers.get('Content-Type')).toBe('image/svg+xml; charset=utf-8');
+	});
+
+	it('returns BADGE_AVAILABLE body when team setup is public', async () => {
+		mockGetBadge.mockReturnValue(undefined);
+		mockGetTeamBadgeState.mockResolvedValue('available');
+		const { GET } = await import('./+server');
+		const res = await GET(makeGetEvent('my-org', 'my-setup'));
+		expect(await res.text()).toBe('<svg>available</svg>');
+	});
+
+	it('returns BADGE_UNAVAILABLE body when team setup is private', async () => {
+		mockGetBadge.mockReturnValue(undefined);
+		mockGetTeamBadgeState.mockResolvedValue('unavailable');
+		const { GET } = await import('./+server');
+		const res = await GET(makeGetEvent('my-org', 'private-setup'));
+		expect(await res.text()).toBe('<svg>unavailable</svg>');
+	});
+
+	it('returns BADGE_UNAVAILABLE body when team setup does not exist', async () => {
+		mockGetBadge.mockReturnValue(undefined);
+		mockGetTeamBadgeState.mockResolvedValue('unavailable');
+		const { GET } = await import('./+server');
+		const res = await GET(makeGetEvent('nobody', 'nothing'));
+		expect(await res.text()).toBe('<svg>unavailable</svg>');
+	});
+
+	it('includes the correct Cache-Control header', async () => {
+		mockGetBadge.mockReturnValue(undefined);
+		mockGetTeamBadgeState.mockResolvedValue('available');
+		const { GET } = await import('./+server');
+		const res = await GET(makeGetEvent('my-org', 'my-setup'));
+		expect(res.headers.get('Cache-Control')).toBe(
+			'public, max-age=300, s-maxage=300, stale-while-revalidate=86400'
+		);
+	});
+
+	it('returns 200 (not 4xx) even when team setup is unavailable', async () => {
+		mockGetBadge.mockReturnValue(undefined);
+		mockGetTeamBadgeState.mockResolvedValue('unavailable');
+		const { GET } = await import('./+server');
+		const res = await GET(makeGetEvent('nobody', 'ghost'));
+		expect(res.status).toBe(200);
+	});
+
+	it('serves the cached SVG without calling getTeamBadgeState on a cache hit', async () => {
+		mockGetBadge.mockReturnValue('<svg>cached</svg>');
+		const { GET } = await import('./+server');
+		const res = await GET(makeGetEvent('my-org', 'my-setup'));
+		expect(await res.text()).toBe('<svg>cached</svg>');
+		expect(mockGetTeamBadgeState).not.toHaveBeenCalled();
+	});
+
+	it('caches the resolved SVG on a cache miss', async () => {
+		mockGetBadge.mockReturnValue(undefined);
+		mockGetTeamBadgeState.mockResolvedValue('available');
+		const { GET } = await import('./+server');
+		await GET(makeGetEvent('my-org', 'my-setup'));
+		expect(mockSetBadge).toHaveBeenCalledWith('team:my-org/my-setup', '<svg>available</svg>');
+	});
+
+	it('uses team:teamSlug/setupSlug as the cache key', async () => {
+		mockGetBadge.mockReturnValue(undefined);
+		mockGetTeamBadgeState.mockResolvedValue('unavailable');
+		const { GET } = await import('./+server');
+		await GET(makeGetEvent('cool-org', 'cool-setup'));
+		expect(mockGetBadge).toHaveBeenCalledWith('team:cool-org/cool-setup');
+		expect(mockSetBadge).toHaveBeenCalledWith('team:cool-org/cool-setup', '<svg>unavailable</svg>');
+	});
+});

--- a/static/brand/coati-mark.svg
+++ b/static/brand/coati-mark.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="Coati mark">
+  <!--
+    Coati mark — single-colour vector.
+    Use fill="currentColor" for CSS-driven recolouring, or replace the
+    hard-coded fill on the <g> element for a fixed colour.
+
+    viewBox: 0 0 100 100  (aspect ratio 1:1)
+  -->
+  <g fill="currentColor">
+    <!-- Body: thick C-arc formed by the coati's tail/body -->
+    <path d="
+      M 72,14
+      C 90,14 96,30 96,50
+      C 96,72 80,90 58,92
+      C 36,94 16,80 10,60
+      C 4,40 14,18 32,10
+      L 35,20
+      C 22,26 15,40 19,55
+      C 23,70 37,80 53,79
+      C 69,78 82,66 82,50
+      C 82,35 76,23 65,20
+      Z
+    "/>
+    <!-- Stripe highlights on the tail arc (lighter band) -->
+    <path d="M 28,12 C 34,9 40,8 40,8 L 37,18 C 37,18 31,19 26,22 Z" opacity="0.45"/>
+    <path d="M 14,30 C 12,36 10,44 11,50 L 21,48 C 20,44 21,38 22,33 Z" opacity="0.45"/>
+    <path d="M 14,62 C 17,70 23,77 30,82 L 34,73 C 29,69 25,64 23,58 Z" opacity="0.45"/>
+    <path d="M 44,88 C 50,91 57,92 63,91 L 60,81 C 55,82 50,82 45,79 Z" opacity="0.45"/>
+    <!-- Head: circle -->
+    <circle cx="70" cy="18" r="14"/>
+    <!-- Ear: small rounded bump at top-left of head -->
+    <circle cx="60" cy="7" r="5"/>
+    <!-- Snout: tapered shape pointing right -->
+    <path d="M 80,15 L 96,19 L 80,25 Z"/>
+    <!-- Eye: small white dot -->
+    <circle cx="74" cy="15" r="3" fill="white"/>
+    <!-- Nose dot -->
+    <circle cx="94" cy="19" r="2" fill="white"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

- chore(seed): embed Clone on Coati badge in seed-setup README content (#362)
- feat(ui): add Embed popover with badge preview to setup pages (#360)
- feat(cli): emit embed snippet after successful publish (#361)
- feat(badge): add team setup badge endpoint for issue #359
- feat(badge): add badge endpoint, cache, and state query for issue #358
- style: fix Prettier formatting in README and LAUNCH-POSTS

Closes #357
Closes #358
Closes #359
Closes #361
Closes #360
Closes #362
Closes #356


## Test plan

See individual issue acceptance criteria for testing details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
